### PR TITLE
Enable fuzzy detection of content-based duplicates

### DIFF
--- a/deduplication.py
+++ b/deduplication.py
@@ -1,0 +1,96 @@
+import re
+from collections import defaultdict
+from typing import Iterable, List
+
+import pandas as pd
+from fuzzywuzzy import fuzz
+
+
+# Regular expression for non-word characters
+_non_word_re = re.compile(r"\W+")
+
+
+def _normalise(text: str) -> str:
+    """Return a normalised representation of *text*.
+
+    The normalisation removes non-word characters and collapses whitespace.
+    ``None`` values are treated as empty strings.
+    """
+    if pd.isna(text):
+        return ""
+    return _non_word_re.sub(" ", str(text).lower()).strip()
+
+
+def find_content_duplicates(
+    df: pd.DataFrame,
+    columns: Iterable[str] | None = None,
+    *,
+    threshold: int = 80,
+) -> pd.DataFrame:
+    """Return rows of *df* that are content duplicates.
+
+    Two rows are considered duplicates if the concatenation of their selected
+    ``columns`` is similar according to ``fuzz.token_set_ratio`` with a score of
+    at least ``threshold`` (0-100).
+
+    Parameters
+    ----------
+    df:
+        The input DataFrame.
+    columns:
+        Iterable of column names to use for the similarity comparison. If
+        ``None`` the default columns ``("title", "jobdescription", "company",
+        "location")`` are used.
+    threshold:
+         Minimum similarity score (0-100) required to treat two rows as
+         duplicates. Defaults to ``80``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A DataFrame containing the duplicate rows. An additional column
+        ``__dup_group`` is added which indicates duplicate group membership.
+    """
+    if columns is None:
+        columns = ("title", "jobdescription", "company", "location")
+
+    # Prepare normalised combined text for each row
+    relevant = df.loc[:, columns].fillna("").map(_normalise)
+    combined = relevant.agg(" ".join, axis=1)
+
+    # Pairwise comparison to find similar rows
+    n = len(df)
+    groups: dict[int, int] = {}
+
+    def find(x: int) -> int:
+        # Disjoint-set find with path compression
+        parent = groups.setdefault(x, x)
+        if parent != x:
+            groups[x] = find(parent)
+        return groups[x]
+
+    def union(x: int, y: int) -> None:
+        root_x, root_y = find(x), find(y)
+        if root_x != root_y:
+            groups[root_y] = root_x
+
+    for i in range(n):
+        text_i = combined.iloc[i]
+        for j in range(i + 1, n):
+            score = fuzz.token_set_ratio(text_i, combined.iloc[j])
+            if score >= threshold:
+                union(i, j)
+
+    # Collect indices belonging to duplicate groups
+    inverse: defaultdict[int, List[int]] = defaultdict(list)
+    for idx in groups:
+        root = find(idx)
+        inverse[root].append(idx)
+
+    dup_indices = [i for lst in inverse.values() if len(lst) > 1 for i in lst]
+    if not dup_indices:
+        return pd.DataFrame(columns=list(df.columns) + ["__dup_group"])
+
+    result = df.loc[dup_indices].copy()
+    result["__dup_group"] = [find(i) for i in dup_indices]
+    return result

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -36,3 +36,18 @@ def test_find_content_duplicates_none():
 
     dup_df = find_content_duplicates(df, threshold=80)
     assert dup_df.empty
+
+
+def test_find_content_duplicates_missing_columns():
+    """Missing optional columns are ignored during duplicate detection."""
+    df = pd.DataFrame({
+        "jobid": [1, 2],
+        # The "title" column is intentionally omitted here
+        "jobdescription": ["Leitung der Stadtbibliothek", "Leitung Stadtbibliothek"],
+        "company": ["Stadtbibliothek Berlin", "Stadt-Bibliothek Berlin"],
+        "location": ["Berlin", "Berlin"],
+    })
+
+    dup_df = find_content_duplicates(df, threshold=80)
+    assert set(dup_df.index) == {0, 1}
+    assert "__dup_group" in dup_df.columns

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from deduplication import find_content_duplicates
+
+
+def test_find_content_duplicates_basic():
+    df = pd.DataFrame({
+        "jobid": [1, 2, 3],
+        "title": ["Bibliothekar", "Bibliothekarin", "Archiv"],
+        "jobdescription": [
+            "Leitung der Stadtbibliothek",
+            "Leitung Stadtbibliothek",
+            "Arbeiten im Archiv",
+        ],
+        "company": ["Stadtbibliothek Berlin", "Stadt-Bibliothek Berlin", "Archiv Berlin"],
+        "location": ["Berlin", "Berlin", "Berlin"],
+    })
+
+    dup_df = find_content_duplicates(df, threshold=80)
+    assert set(dup_df.index) == {0, 1}
+    assert len(dup_df) == 2
+
+
+def test_find_content_duplicates_none():
+    df = pd.DataFrame({
+        "jobid": [1, 2],
+        "title": ["Alpha", "Beta"],
+        "jobdescription": ["Erste Beschreibung", "Zweite Info"],
+        "company": ["Firma Eins", "Unternehmen Zwei"],
+        "location": ["Ort A", "Ort B"],
+    })
+
+    dup_df = find_content_duplicates(df, threshold=80)
+    assert dup_df.empty


### PR DESCRIPTION
This pull request introduces a new content-based duplicate detection feature for dataframes, refactors the duplicate display logic in the UI, and adds accompanying tests for the new deduplication logic. The main improvement is that duplicate detection now uses fuzzy matching on the content of selected columns rather than relying solely on exact row duplication. This results in more accurate identification and visualization of similar entries.

**Deduplication logic and core functionality:**
* Added `find_content_duplicates` in `deduplication.py`, which detects duplicate rows in a dataframe by comparing the combined content of selected columns using fuzzy string matching (`fuzz.token_set_ratio`). Duplicate groups are returned with a helper column for group membership.

**UI integration and visualization:**
* Refactored duplicate detection in the UI (`start.py`) to use `find_content_duplicates`, and updated the row coloring logic to highlight duplicate groups based on content similarity rather than exact matches. The new approach uses the `__dup_group` column to color-code groups.

**Testing:**
* Added `tests/test_deduplication.py` with tests for the new deduplication logic, covering both basic duplicate detection and cases with no duplicates.