### PR TITLE
Add fuzzy duplicate removal workflow

### DIFF
--- a/duplicates.py
+++ b/duplicates.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from fuzzywuzzy import fuzz
+
+
+def find_and_remove_duplicates(df: pd.DataFrame, threshold: int = 90, progress_callback=None):
+    """Find duplicates based on fuzzy matching of selected columns.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe.
+    threshold : int, optional
+        Similarity threshold for considering rows as duplicates (0-100).
+    progress_callback : callable, optional
+        Function called with progress percentage (0-100).
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame]
+        Tuple of (deduplicated dataframe, dataframe of duplicates).
+    """
+    columns = ["company", "location", "jobtype", "jobdescription"]
+    if not set(columns).issubset(df.columns):
+        raise ValueError("Dataframe must contain company, location, jobtype and jobdescription columns")
+
+    combined = (
+        df[columns]
+        .fillna("")
+        .agg(" ".join, axis=1)
+    )
+
+    duplicate_indices = set()
+    duplicates_rows = []
+    total = len(df)
+    for i in range(total):
+        if progress_callback:
+            progress_callback(int((i / max(total - 1, 1)) * 100))
+        if i in duplicate_indices:
+            continue
+        for j in range(i + 1, total):
+            if j in duplicate_indices:
+                continue
+            score = fuzz.token_set_ratio(combined.iloc[i], combined.iloc[j])
+            if score >= threshold:
+                duplicate_indices.add(j)
+                duplicates_rows.append(df.iloc[j])
+    if progress_callback:
+        progress_callback(100)
+    duplicates_df = pd.DataFrame(duplicates_rows, columns=df.columns)
+    deduped_df = df.drop(index=list(duplicate_indices)).reset_index(drop=True)
+    return deduped_df, duplicates_df.reset_index(drop=True)
+

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+from duplicates import find_and_remove_duplicates
+
+
+def test_find_and_remove_duplicates():
+    df = pd.DataFrame({
+        'company': ['M\u00fcller GmbH', 'Mueller GmbH', 'Schmidt AG'],
+        'location': ['Berlin', 'Berlin', 'Hamburg'],
+        'jobtype': ['Bibliothekar', 'Bibliothekar', 'Archiv'],
+        'jobdescription': ['Verwaltung der Bibliothek', 'Verwaltung Bibliothek', 'Archivierung']
+    })
+    cleaned, duplicates = find_and_remove_duplicates(df, threshold=85)
+    assert len(cleaned) == 2
+    assert len(duplicates) == 1
+    assert duplicates.iloc[0]['company'] == 'Mueller GmbH'
+


### PR DESCRIPTION
This pull request adds fuzzy duplicate detection and removal functionality to the application, allowing users to identify and remove similar job postings based on selected fields. The main window now includes a button to trigger deduplication, and results are shown in a new dialog. The changes also include a background worker for deduplication and a corresponding unit test.

### Deduplication Feature Integration

* Added a new function `find_and_remove_duplicates` in `duplicates.py` to perform fuzzy matching on job postings and return deduplicated and duplicate dataframes.
* Integrated the deduplication process into the GUI: Added a "Dubletten entfernen" button to the main window, which runs the deduplication in a background thread and displays progress. [[1]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR122-R125) [[2]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR84-R102) [[3]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR207-R250)
* Added the `DuplicatesWindow` class to display found duplicates in a table, with proper resource cleanup on close.

### Testing

* Added a unit test for the deduplication logic in `tests/test_deduplicate.py`, verifying correct identification of duplicates.

### Minor Integration

* Imported the deduplication function in `start.py` for use in the main application logic.