### PR TITLE
Fix linter warnings in start.py

### DIFF
--- a/start.py
+++ b/start.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from typing import cast
+from typing import cast, TypeVar
 
 import pandas as pd
 from PyQt5 import QtCore, QtWidgets, QtGui
@@ -35,6 +35,16 @@ ERROR_TYPES = [
     "Duplikate",
     "Datenkonflikte",
 ]
+
+
+T = TypeVar("T")
+
+
+def _require(value: T | None, name: str) -> T:
+    """Return *value* if it is not ``None`` or raise ``RuntimeError``."""
+    if value is None:
+        raise RuntimeError(f"{name} is unexpectedly None")
+    return value
 
 
 class LoadWorker(QtCore.QObject):
@@ -270,13 +280,11 @@ class ProfileWindow(QtWidgets.QMainWindow):
         self.setCentralWidget(container)
 
         # ``verticalHeader`` and ``verticalScrollBar`` are guaranteed to return
-        # valid objects at runtime but are typed as optional, so we assign them to
-        # local variables before accessing their attributes.
-        header = table.verticalHeader()
-        assert header is not None
+        # valid objects at runtime but are typed as optional, so we resolve them
+        # through a helper to enforce non-``None`` values.
+        header = _require(table.verticalHeader(), "verticalHeader")
         total_width = header.width() + table.frameWidth() * 2
-        v_scroll = table.verticalScrollBar()
-        assert v_scroll is not None
+        v_scroll = _require(table.verticalScrollBar(), "verticalScrollBar")
         total_width += v_scroll.sizeHint().width()
         for i in range(table.columnCount()):
             total_width += table.columnWidth(i)
@@ -369,11 +377,9 @@ class DuplicatesWindow(QtWidgets.QMainWindow):
         table.resizeColumnsToContents()
         layout.addWidget(table)
         self.setCentralWidget(container)
-        header = table.verticalHeader()
-        assert header is not None
+        header = _require(table.verticalHeader(), "verticalHeader")
         total_width = header.width() + table.frameWidth() * 2
-        v_scroll = table.verticalScrollBar()
-        assert v_scroll is not None
+        v_scroll = _require(table.verticalScrollBar(), "verticalScrollBar")
         total_width += v_scroll.sizeHint().width()
         for i in range(table.columnCount()):
             total_width += table.columnWidth(i)


### PR DESCRIPTION
This pull request focuses on improving type safety and static type checker compatibility in the `start.py` file. The changes clarify PyQt5 API usage, add explicit type annotations, and ensure safer attribute access, which will help prevent runtime errors and make the code easier to maintain.

Type safety and static type checker compatibility:

* Replaced ambiguous attribute access for status bars and widget attributes with explicit type annotations and usage of `QtCore.Qt.WidgetAttribute.WA_DeleteOnClose` instead of `QtCore.Qt.WA_DeleteOnClose` to satisfy static type checkers. [[1]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fL95-R100) [[2]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fL162-R170) [[3]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fL219-R227)
* Added explicit type casting and assertions when accessing PyQt objects (e.g., `verticalHeader`, `verticalScrollBar`, and `pyqtBoundSignal`) to ensure type checkers recognize their validity and to prevent possible `NoneType` errors. [[1]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fL264-R280) [[2]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fL321-R341) [[3]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fL348-R377)

Robustness improvements:

* Added a check for `None` before setting the background color of table items, preventing potential runtime errors when working with table cells.

General code quality:

* Imported `cast` from `typing` for type-safe casting, supporting the above improvements.