### PR TITLE
Fix pandas read_csv path type in load_bibliojobs

### DIFF
--- a/load_bibliojobs.py
+++ b/load_bibliojobs.py
@@ -8,7 +8,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 def load_bibliojobs(
-    path: Union[str, bytes] = "bibliojobs_raw.csv",
+    path: Union[str, os.PathLike[str]] = "bibliojobs_raw.csv",
     *,
     date_format: str = "%d-%m-%Y",
     progress_callback: Optional[Callable[[float], None]] = None,
@@ -32,7 +32,7 @@ def load_bibliojobs(
     pandas.DataFrame
         DataFrame with normalised column names and corrected dtypes.
     """
-    path_str = os.fspath(path)
+    path_str: str = os.fspath(path)
     if not os.path.exists(path_str):
         raise FileNotFoundError(f"CSV-Datei nicht gefunden: {path_str}")
 


### PR DESCRIPTION
This pull request makes a minor improvement to the type hinting for the `path` parameter in the `load_bibliojobs` function, increasing clarity and compatibility with different path types.

* Changed the type hint for the `path` parameter in `load_bibliojobs` from `Union[str, bytes]` to `Union[str, os.PathLike[str]]` to better reflect accepted path types.
* Added an explicit type annotation to the `path_str` variable to clarify its type as `str`.