### PR TITLE
Enhance duplicate detection with employment details

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -816,6 +816,8 @@ def find_fuzzy_duplicates(
                 val_j = row_j.get(col)
                 if pd.isna(val_i) and pd.isna(val_j):
                     col_sim = 100
+                elif pd.isna(val_i) or pd.isna(val_j):
+                    col_sim = 0
                 else:
                     col_sim = fuzz.token_set_ratio(str(val_i), str(val_j))
                 if col_sim < threshold:

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -69,3 +69,24 @@ def test_no_duplicates_when_workinghours_differs():
 
     assert duplicates.empty
     assert len(cleaned) == 2
+
+
+def test_no_false_duplicates_with_missing_vs_string_value():
+    df = pd.DataFrame({
+        "company": ["ABC GmbH", "ABC GmbH"],
+        "location": ["Berlin", "Berlin"],
+        "jobtype": ["Librarian", "Librarian"],
+        "jobdescription": ["Manage books", "Manage books"],
+        "fixedterm": [None, None],
+        "workinghours": ["Vollzeit", "Vollzeit"],
+        "salary": [None, "None provided"],
+    })
+
+    cleaned, duplicates = find_fuzzy_duplicates(
+        df,
+        DEDUPLICATE_COLUMNS,
+        threshold=90,
+    )
+
+    assert duplicates.empty
+    assert len(cleaned) == 2

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -9,6 +9,9 @@ def test_find_fuzzy_duplicates():
         "location": ["Berlin", "Berlin", "Hamburg"],
         "jobtype": ["Librarian", "Librarian", "Archivist"],
         "jobdescription": ["Manage books", "manage books", "Archive documents"],
+        "fixedterm": [None, None, None],
+        "workinghours": ["Vollzeit", "Vollzeit", "Teilzeit"],
+        "salary": ["E 9", "E 9", "E 7"],
     })
 
     cleaned, duplicates = find_fuzzy_duplicates(
@@ -32,6 +35,30 @@ def test_no_false_duplicates_with_different_company():
         "location": ["Berlin", "Berlin"],
         "jobtype": ["Librarian", "Librarian"],
         "jobdescription": ["Manage books", "Manage books"],
+        "fixedterm": [None, None],
+        "workinghours": ["Vollzeit", "Vollzeit"],
+        "salary": ["E 9", "E 9"],
+    })
+
+    cleaned, duplicates = find_fuzzy_duplicates(
+        df,
+        DEDUPLICATE_COLUMNS,
+        threshold=90,
+    )
+
+    assert duplicates.empty
+    assert len(cleaned) == 2
+
+
+def test_no_duplicates_when_workinghours_differs():
+    df = pd.DataFrame({
+        "company": ["ABC GmbH", "A.B.C. GmbH"],
+        "location": ["Berlin", "Berlin"],
+        "jobtype": ["Librarian", "Librarian"],
+        "jobdescription": ["Manage books", "manage books"],
+        "fixedterm": [None, None],
+        "workinghours": ["Vollzeit", "Teilzeit"],
+        "salary": ["E 9", "E 9"],
     })
 
     cleaned, duplicates = find_fuzzy_duplicates(


### PR DESCRIPTION
This pull request enhances the duplicate detection logic in job listings by expanding the set of columns considered for fuzzy matching and improving the deduplication tests to cover new scenarios. The main focus is on making duplicate detection more robust by including additional job attributes and ensuring the logic works as expected through extended test coverage.

### Improvements to duplicate detection logic

* Expanded the `DEDUPLICATE_COLUMNS` list in `cleaning.py` to include `fixedterm`, `workinghours`, and `salary`, so these fields are now considered when identifying duplicates.
* Updated the `find_fuzzy_duplicates` function to compare the new columns using fuzzy matching, ensuring that all specified columns must be similar enough for rows to be considered duplicates.

### Enhanced test coverage

* Modified existing tests in `tests/test_duplicates.py` to include the new columns (`fixedterm`, `workinghours`, and `salary`) in test data, ensuring the deduplication logic is validated against these fields. [[1]](diffhunk://#diff-6d7b73e9211e7fd33f636af1f7558ee0da52196c2d8deda7ad5c5710ada497cbR12-R14) [[2]](diffhunk://#diff-6d7b73e9211e7fd33f636af1f7558ee0da52196c2d8deda7ad5c5710ada497cbR38-R61)
* Added a new test `test_no_duplicates_when_workinghours_differs` to verify that rows with different `workinghours` values are not incorrectly marked as duplicates.