### PR TITLE
Group duplicate records by retained entry

### DIFF
--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,7 +1,5 @@
 import pandas as pd
 
-import pandas as pd
-
 from cleaning import DEDUPLICATE_COLUMNS, find_fuzzy_duplicates
 
 

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+import pandas as pd
+
 from cleaning import DEDUPLICATE_COLUMNS, find_fuzzy_duplicates
 
 
@@ -69,6 +71,36 @@ def test_no_duplicates_when_workinghours_differs():
 
     assert duplicates.empty
     assert len(cleaned) == 2
+
+
+def test_multiple_duplicates_are_grouped():
+    df = pd.DataFrame(
+        {
+            "company": ["ABC GmbH", "A.B.C. GmbH", "A B C GmbH", "XYZ AG"],
+            "location": ["Berlin", "Berlin", "Berlin", "Hamburg"],
+            "jobtype": ["Librarian", "Librarian", "Librarian", "Archivist"],
+            "jobdescription": [
+                "Manage books",
+                "manage books",
+                "Manage books",
+                "Archive documents",
+            ],
+            "fixedterm": [None, None, None, None],
+            "workinghours": ["Vollzeit", "Vollzeit", "Vollzeit", "Teilzeit"],
+            "salary": ["E 9", "E 9", "E 9", "E 7"],
+        }
+    )
+
+    _, duplicates = find_fuzzy_duplicates(
+        df,
+        DEDUPLICATE_COLUMNS,
+        threshold=90,
+    )
+
+    assert len(duplicates) == 3
+    assert duplicates["pair_id"].nunique() == 1
+    assert duplicates.iloc[0]["keep"]
+    assert (duplicates.iloc[1:]["keep"] == False).all()
 
 
 def test_no_false_duplicates_with_missing_vs_string_value():


### PR DESCRIPTION
This pull request refactors the duplicate detection logic in `cleaning.py` to improve how groups of fuzzy duplicates are identified and represented. It changes the internal data structure from a flat list of pairs to a dictionary grouping all duplicates under a single recommended record, and updates the test suite to verify correct grouping behavior.

**Deduplication logic improvements:**

* Refactored the internal representation of duplicates in `find_fuzzy_duplicates` from a list of (keep, drop) pairs to a dictionary mapping each recommended record to a list of its duplicates, allowing for grouping multiple related records together. [[1]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL787-R788) [[2]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL836-R853)
* Updated the docstring for `find_fuzzy_duplicates` to clarify that the returned duplicates dataframe groups related records by `pair_id`, with one recommended entry (`keep=True`) and all others marked for removal (`keep=False`).

**Testing enhancements:**

* Added a new test `test_multiple_duplicates_are_grouped` to `tests/test_duplicates.py`, ensuring that multiple fuzzy duplicates are correctly grouped under a single `pair_id` and only one record is marked as `keep=True`.
* Minor import cleanup in `tests/test_duplicates.py`.