### PR TITLE
Add export option for detected duplicates

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -919,3 +919,33 @@ def find_fuzzy_duplicates(
     cleaned = df.drop(index=drop_indices).reset_index(drop=True)
     return cleaned, duplicates
 
+
+def prepare_duplicates_export(duplicates: pd.DataFrame) -> pd.DataFrame:
+    """Prepare duplicates dataframe for CSV export.
+
+    Adds a ``duplicate_of`` column referencing the ``orig_index`` of the
+    record that should be kept for each pair. Rows marked with ``keep=True``
+    will have ``duplicate_of`` set to :data:`pandas.NA`.
+
+    Parameters
+    ----------
+    duplicates : pd.DataFrame
+        Dataframe as returned by :func:`find_fuzzy_duplicates`.
+
+    Returns
+    -------
+    pd.DataFrame
+        A copy of ``duplicates`` with the additional ``duplicate_of`` column.
+    """
+
+    if duplicates.empty:
+        return duplicates.copy()
+
+    pair_to_original = (
+        duplicates[duplicates["keep"]].set_index("pair_id")["orig_index"]
+    )
+    export_df = duplicates.copy()
+    export_df["duplicate_of"] = export_df["pair_id"].map(pair_to_original)
+    export_df.loc[export_df["keep"], "duplicate_of"] = pd.NA
+    return export_df
+

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,6 +1,10 @@
 import pandas as pd
 
-from cleaning import DEDUPLICATE_COLUMNS, find_fuzzy_duplicates
+from cleaning import (
+    DEDUPLICATE_COLUMNS,
+    find_fuzzy_duplicates,
+    prepare_duplicates_export,
+)
 
 
 def test_find_fuzzy_duplicates_new_rules():
@@ -60,3 +64,36 @@ def test_no_duplicates_when_jobtype_differs():
 
     assert duplicates.empty
     assert len(cleaned) == 2
+
+
+def test_prepare_duplicates_export_adds_reference():
+    df = pd.DataFrame(
+        {
+            "jobdescription": [
+                "Manage books and media",
+                "Manage books and archives",
+            ],
+            "jobtype": ["Librarian", "Librarian"],
+            "company": ["ABC GmbH", "ABCD GmbH"],
+            "insttype": ["Public", "Public"],
+            "location": ["Berlin", "Berlin"],
+            "country": ["DE", "DE"],
+            "geo_lat": [52.52, 52.5205],
+            "geo_lon": [13.405, 13.4055],
+            "plz": ["10115", "10116"],
+            "fixedterm": ["No", "No"],
+            "workinghours": ["Vollzeit", "Vollzeit"],
+            "salary": ["E9", "E9"],
+        }
+    )
+
+    _, duplicates = find_fuzzy_duplicates(
+        df, DEDUPLICATE_COLUMNS, threshold=80
+    )
+
+    export_df = prepare_duplicates_export(duplicates)
+    assert "duplicate_of" in export_df.columns
+    keep_row = export_df[export_df["keep"]].iloc[0]
+    dup_row = export_df[~export_df["keep"]].iloc[0]
+    assert pd.isna(keep_row["duplicate_of"])
+    assert dup_row["duplicate_of"] == keep_row["orig_index"]


### PR DESCRIPTION
This pull request adds functionality for exporting duplicate detection results, improves the user interface with an export button, and introduces a new utility for preparing duplicate data for export. It also includes corresponding tests to ensure the new export logic works correctly.

**Export functionality and UI improvements:**

* Added a new `prepare_duplicates_export` function in `cleaning.py` to generate a DataFrame suitable for CSV export, including a `duplicate_of` column referencing the original record for each duplicate.
* Updated the duplicate review dialog in `start.py` to add an "Ergebnisse exportieren" (Export Results) button, allowing users to export duplicate results to a CSV file. [[1]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR490-R498) [[2]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR548-R565)

**Testing and code organization:**

* Imported and tested the new `prepare_duplicates_export` function in `tests/test_duplicates.py`, verifying that the exported DataFrame includes correct references for duplicates. [[1]](diffhunk://#diff-6d7b73e9211e7fd33f636af1f7558ee0da52196c2d8deda7ad5c5710ada497cbL3-R7) [[2]](diffhunk://#diff-6d7b73e9211e7fd33f636af1f7558ee0da52196c2d8deda7ad5c5710ada497cbR67-R99)
* Updated imports in `start.py` to include the new export utility.