### PR TITLE
Switch to rapidfuzz for string matching

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 
 import pandas as pd
 import requests
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.neighbors import NearestNeighbors
 
@@ -197,7 +197,7 @@ def consolidate_similar_companies(series: pd.Series, threshold: int = 85) -> pd.
                 continue
                 
             # Use fuzzy matching to compare names
-            similarity = fuzz.ratio(str(value1).lower(), str(value2).lower())
+            similarity = int(fuzz.ratio(str(value1).lower(), str(value2).lower()))
             
             if similarity >= threshold:
                 group.append(value2)
@@ -832,7 +832,7 @@ def find_fuzzy_duplicates(
         
         # Must have significant overlap
         if len(c1) > 10 and len(c2) > 10:
-            score = fuzz.token_sort_ratio(c1, c2)
+            score = int(fuzz.token_sort_ratio(c1, c2))
             return score >= 85
         
         return True
@@ -848,7 +848,7 @@ def find_fuzzy_duplicates(
         if l1 == l2:
             return True
         
-        score = fuzz.ratio(l1, l2)
+        score = int(fuzz.ratio(l1, l2))
         return score >= 90
     
     # Stage 2: Within each group, apply very strict fuzzy matching
@@ -899,7 +899,7 @@ def find_fuzzy_duplicates(
                     desc1 = str(row_i.get('jobdescription', '')).lower()
                     desc2 = str(row_j.get('jobdescription', '')).lower()
                     if len(desc1) > 10 and len(desc2) > 10:
-                        desc_score = fuzz.token_sort_ratio(desc1, desc2)
+                        desc_score = int(fuzz.token_sort_ratio(desc1, desc2))
                         if desc_score < 95:
                             continue
                 
@@ -920,7 +920,7 @@ def find_fuzzy_duplicates(
                         match = False
                         break
                     
-                    score = fuzz.token_sort_ratio(str(val_i), str(val_j))
+                    score = int(fuzz.token_sort_ratio(str(val_i), str(val_j)))
                     
                     # Very high threshold for each field
                     min_score = 95 if col == 'jobdescription' else 90

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas
 numpy
 openpyxl
-fuzzywuzzy[speedup]
+rapidfuzz
 scikit-learn
 sqlalchemy
 mysqlclient


### PR DESCRIPTION
This pull request updates the fuzzy string matching library used in `cleaning.py` and standardizes the output of similarity scores to integers throughout the code. The most important changes are grouped below:

Library update:

* Replaced the `fuzzywuzzy` library with `rapidfuzz` for string similarity calculations by changing the import statement in `cleaning.py`.

Code consistency and compatibility:

* Wrapped all calls to `fuzz.ratio` and `fuzz.token_sort_ratio` with `int()` to ensure similarity scores are always integers, which improves consistency and prevents potential type issues in downstream logic. [[1]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL200-R200) [[2]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL835-R835) [[3]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL851-R851) [[4]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL902-R902) [[5]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL923-R923)