### PR TITLE
Export only selected duplicates with custom delimiter

### DIFF
--- a/start.py
+++ b/start.py
@@ -556,8 +556,15 @@ class DuplicatesWindow(QtWidgets.QMainWindow):
         )
         if not path:
             return
+        selected = [
+            self._checkbox_map[cb] for cb in self._checkboxes if cb.isChecked()
+        ]
         export_df = prepare_duplicates_export(self._dataframe)
-        export_df.to_csv(path, index=False)
+        export_df = export_df[
+            (~export_df["keep"]) & (export_df["orig_index"].isin(selected))
+        ]
+        export_df = export_df.drop(columns=["keep", "pair_id", "orig_index"])
+        export_df.to_csv(path, index=False, sep="_§_")
         if os.environ.get("QT_QPA_PLATFORM") != "offscreen":
             QtWidgets.QMessageBox.information(
                 self,

--- a/start.py
+++ b/start.py
@@ -564,7 +564,16 @@ class DuplicatesWindow(QtWidgets.QMainWindow):
             (~export_df["keep"]) & (export_df["orig_index"].isin(selected))
         ]
         export_df = export_df.drop(columns=["keep", "pair_id", "orig_index"])
-        export_df.to_csv(path, index=False, sep="_§_")
+
+        # pandas' to_csv supports only single-character separators. Write the CSV
+        # using a placeholder character and replace it with the desired multi-
+        # character delimiter afterwards so that the exported file uses ``_§_``
+        # like the original data source.
+        placeholder = "\x1f"  # unit separator, unlikely to appear in data
+        csv_data = export_df.to_csv(index=False, sep=placeholder)
+        csv_data = csv_data.replace(placeholder, "_§_")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(csv_data)
         if os.environ.get("QT_QPA_PLATFORM") != "offscreen":
             QtWidgets.QMessageBox.information(
                 self,

--- a/start.py
+++ b/start.py
@@ -571,7 +571,7 @@ class DuplicatesWindow(QtWidgets.QMainWindow):
         # like the original data source.
         placeholder = "\x1f"  # unit separator, unlikely to appear in data
         csv_data = export_df.to_csv(
-            index=False, sep=placeholder, line_terminator="\n"
+            index=False, sep=placeholder, lineterminator="\n"
         )
         csv_data = csv_data.replace(placeholder, "_§_")
         with open(path, "w", encoding="utf-8", newline="") as f:

--- a/start.py
+++ b/start.py
@@ -570,9 +570,11 @@ class DuplicatesWindow(QtWidgets.QMainWindow):
         # character delimiter afterwards so that the exported file uses ``_§_``
         # like the original data source.
         placeholder = "\x1f"  # unit separator, unlikely to appear in data
-        csv_data = export_df.to_csv(index=False, sep=placeholder)
+        csv_data = export_df.to_csv(
+            index=False, sep=placeholder, line_terminator="\n"
+        )
         csv_data = csv_data.replace(placeholder, "_§_")
-        with open(path, "w", encoding="utf-8") as f:
+        with open(path, "w", encoding="utf-8", newline="") as f:
             f.write(csv_data)
         if os.environ.get("QT_QPA_PLATFORM") != "offscreen":
             QtWidgets.QMessageBox.information(


### PR DESCRIPTION
This pull request updates the export functionality in the `_export_results` method of `start.py` to filter and format the exported results based on user selection. The export now only includes unchecked duplicate entries that the user has selected, and the output format has been adjusted for improved downstream processing.

Export logic improvements:

* The export now filters the DataFrame to only include rows where `keep` is `False` and the `orig_index` matches the user-selected checkboxes.
* The export removes unnecessary columns (`keep`, `pair_id`, `orig_index`) before saving the file.
* The CSV separator has been changed to `_§_` for better compatibility with downstream tools.