### PR TITLE
Ensure duplicate export CSV uses underscored uppercase headers

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -1138,3 +1138,24 @@ def prepare_duplicates_export(duplicates: pd.DataFrame) -> pd.DataFrame:
     export_df.loc[export_df["keep"], "duplicate_of"] = pd.NA
     return export_df
 
+
+def format_export_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of ``df`` with column names formatted for export.
+
+    Column labels are converted to upper case and wrapped with leading and
+    trailing underscores as required by the export specification.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame whose columns should be formatted.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``df`` with renamed columns.
+    """
+
+    renamed = {col: f"_{col.upper()}_" for col in df.columns}
+    return df.rename(columns=renamed)
+

--- a/start.py
+++ b/start.py
@@ -20,6 +20,7 @@ from cleaning import (
     find_fuzzy_duplicates,
     DEDUPLICATE_COLUMNS,
     prepare_duplicates_export,
+    format_export_columns,
 )
 
 
@@ -601,6 +602,7 @@ class DuplicatesWindow(QtWidgets.QMainWindow):
             (~export_df["keep"]) & (export_df["orig_index"].isin(selected))
         ]
         export_df = export_df.drop(columns=["keep", "pair_id", "orig_index"])
+        export_df = format_export_columns(export_df)
 
         # pandas' to_csv supports only single-character separators. Write the CSV
         # using a placeholder character and replace it with the desired multi-

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -10,6 +10,7 @@ from cleaning import (
     DEDUPLICATE_COLUMNS,
     find_fuzzy_duplicates,
     prepare_duplicates_export,
+    format_export_columns,
     clean_dataframe,
     generate_candidate_pairs,
 )
@@ -55,6 +56,18 @@ def test_prepare_duplicates_export_adds_reference(duplicates_df: pd.DataFrame) -
     dup_row = export_df[~export_df["keep"]].iloc[0]
     assert pd.isna(keep_row["duplicate_of"])
     assert dup_row["duplicate_of"] == keep_row["orig_index"]
+
+
+def test_format_export_columns_applies_required_style(
+    duplicates_df: pd.DataFrame,
+) -> None:
+    export_df = prepare_duplicates_export(duplicates_df)
+    export_df = export_df[~export_df["keep"]]
+    export_df = export_df.drop(columns=["keep", "pair_id", "orig_index"])
+    original_cols = export_df.columns.tolist()
+    formatted = format_export_columns(export_df)
+    expected = [f"_{c.upper()}_" for c in original_cols]
+    assert list(formatted.columns) == expected
 
 
 def test_generate_candidate_pairs_limits_comparisons() -> None:


### PR DESCRIPTION
This pull request introduces a new utility function to standardize column formatting for exported dataframes, ensuring compliance with the export specification. The changes integrate this function into the export pipeline and add corresponding tests to verify correct behavior.

**Export formatting improvements:**

* Added the `format_export_columns` function in `cleaning.py` to convert dataframe column names to upper case and wrap them with underscores for export compliance.
* Integrated `format_export_columns` into the export workflow in `start.py`, ensuring all exported CSVs have correctly formatted column names.
* Updated imports in both `start.py` and `tests/test_duplicates.py` to include the new formatting function. [[1]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR23) [[2]](diffhunk://#diff-6d7b73e9211e7fd33f636af1f7558ee0da52196c2d8deda7ad5c5710ada497cbR13)

**Testing enhancements:**

* Added `test_format_export_columns_applies_required_style` in `tests/test_duplicates.py` to verify that exported columns are formatted according to specification.