### PR TITLE
Add fuzzy region matching for location enrichment

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -9,6 +9,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.neighbors import NearestNeighbors
 
 from license_plates import fetch_german_license_plates, resolve_license_plates_in_series
+from region_mapper import match_region_fuzzy
 from utils import make_status_printer
 
 
@@ -466,6 +467,7 @@ def clean_dataframe(
     df: pd.DataFrame,
     progress_callback: Optional[Callable[[float], None]] = None,
     status_callback: Optional[Callable[[str], None]] = None,
+    region_mapping: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """Return a cleaned copy of *df* with HTML entities decoded, tags removed,
     license plates resolved, company names standardized, and PLZ extracted to separate column.
@@ -543,6 +545,16 @@ def clean_dataframe(
         cleaned['fixedterm'] = fixedterm
         cleaned['workinghours'] = workinghours
         cleaned['salary'] = salary
+
+    # Enrich with region information if mapping provided
+    if region_mapping is not None and 'location' in cleaned.columns:
+        region_map = region_mapping.set_index('location')['region']
+        cleaned['region'] = cleaned['location'].map(region_map)
+        missing_mask = cleaned['region'].isna() & cleaned['location'].notna()
+        if missing_mask.any():
+            cleaned.loc[missing_mask, 'region'] = cleaned.loc[missing_mask, 'location'].apply(
+                lambda loc: match_region_fuzzy(loc, region_mapping)
+            )
 
     if progress_callback:
         progress_callback(100.0)

--- a/region_mapper.py
+++ b/region_mapper.py
@@ -1,0 +1,39 @@
+import pandas as pd
+from rapidfuzz import process
+from typing import Optional
+
+def match_region_fuzzy(location: str, mapping: pd.DataFrame, threshold: int = 90) -> Optional[str]:
+    """Return region name for *location* using fuzzy matching.
+
+    Parameters
+    ----------
+    location : str
+        Location string to match.
+    mapping : pd.DataFrame
+        DataFrame with at least columns ``location`` and ``region``.
+    threshold : int, optional
+        Minimum similarity score (0-100) required to accept a match.
+        Defaults to 90.
+
+    Returns
+    -------
+    Optional[str]
+        Region name if a match above ``threshold`` is found, ``None`` otherwise.
+    """
+    if not isinstance(location, str) or not location.strip():
+        return None
+
+    choices = mapping["location"].dropna().astype(str).tolist()
+    if not choices:
+        return None
+
+    result = process.extractOne(location, choices, score_cutoff=threshold)
+    if result is None:
+        return None
+
+    matched_name, score, idx = result
+    try:
+        return mapping.iloc[idx]["region"]
+    except Exception:
+        return None
+

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -288,3 +288,21 @@ def test_integration_clean_dataframe_real_api():
     
     # At least "Frankfurt" should remain unchanged
     assert "Frankfurt" in cleaned_location
+
+
+def test_region_enrichment_fuzzy():
+    """Ensure fuzzy region matching enriches locations with minor variations."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch:
+        mock_fetch.return_value = {}
+
+        df = pd.DataFrame({"location": ["Berlin", "Münchenn", "Hamburg"]})
+        mapping = pd.DataFrame(
+            {"location": ["Berlin", "München"], "region": ["Berlin", "Bayern"]}
+        )
+
+        cleaned = clean_dataframe(df, region_mapping=mapping)
+
+        assert cleaned.loc[0, "region"] == "Berlin"  # exact match
+        assert cleaned.loc[1, "region"] == "Bayern"  # fuzzy match
+        assert pd.isna(cleaned.loc[2, "region"])  # no match
+


### PR DESCRIPTION
## Summary
- add `match_region_fuzzy` using rapidfuzz to map locations to regions
- enrich `clean_dataframe` with region mapping and fallback fuzzy matching
- test fuzzy region enrichment on near-miss location names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2060e217c832e8e42f94229a79e6e