### PR TITLE
Fix city extraction for incorrect location values

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -537,7 +537,8 @@ def clean_dataframe(
             ) & city_extracted.notna()
             cleaned.loc[mask, 'location'] = city_extracted[mask]
         else:
-            cleaned['location'] = city_extracted
+            if city_extracted.notna().any():
+                cleaned['location'] = city_extracted
 
         _status(f"PLZ extrahiert: {plz_extracted.notna().sum()} Einträge gefunden")
     

--- a/cleaning.py
+++ b/cleaning.py
@@ -28,8 +28,10 @@ DEDUPLICATE_COLUMNS = [
     "salary",
 ]
 
-def extract_plz_from_company(series: pd.Series) -> tuple[pd.Series, pd.Series]:
-    """Extract postal codes from company names and return cleaned company names and PLZ.
+def extract_plz_from_company(
+    series: pd.Series,
+) -> tuple[pd.Series, pd.Series, pd.Series]:
+    """Extract postal codes and cities from company names.
     
     Parameters
     ----------
@@ -38,45 +40,58 @@ def extract_plz_from_company(series: pd.Series) -> tuple[pd.Series, pd.Series]:
         
     Returns
     -------
-    tuple[pd.Series, pd.Series]
-        Tuple of (cleaned_company_names, extracted_plz)
+    tuple[pd.Series, pd.Series, pd.Series]
+        Tuple of ``(cleaned_company_names, extracted_plz, extracted_city)``
     """
-    
-    def extract_plz_and_clean(value):
+
+    def extract_plz_city_and_clean(value):
         if pd.isna(value):
-            return value, None
-        
+            return value, None, None
+
         value_str = str(value).strip()
         extracted_plz = None
-        
-        # Extract German postal codes (5 digits) with optional city
-        # Patterns: ", 12345 Stadt" or ", 12345" at end of string
-        plz_pattern = r',\s*(\d{5})(?:\s+[A-ZÄÖÜ][a-zäöüß\s-]+)?$'
-        match = re.search(plz_pattern, value_str, flags=re.IGNORECASE)
-        
+        extracted_city = None
+
+        # Pattern: ", 12345 Stadt" at end of string
+        plz_city_comma = r',\s*(\d{5})\s+([A-ZÄÖÜ][a-zäöüß\s-]+)$'
+        match = re.search(plz_city_comma, value_str, flags=re.IGNORECASE)
         if match:
             extracted_plz = match.group(1)
-            # Remove the entire PLZ+city part from company name
-            value_str = re.sub(plz_pattern, '', value_str, flags=re.IGNORECASE)
+            extracted_city = match.group(2).strip()
+            value_str = re.sub(plz_city_comma, '', value_str, flags=re.IGNORECASE)
         else:
-            # Try to find PLZ without comma (less common but happens)
-            # Pattern: " 12345 Stadt" or " 12345" at end, but be careful not to match job IDs etc.
-            plz_pattern_no_comma = r'\s+(\d{5})\s+[A-ZÄÖÜ][a-zäöüß\s-]+$'
-            match = re.search(plz_pattern_no_comma, value_str, flags=re.IGNORECASE)
+            # Pattern: " 12345 Stadt" without comma
+            plz_city_no_comma = r'\s+(\d{5})\s+([A-ZÄÖÜ][a-zäöüß\s-]+)$'
+            match = re.search(plz_city_no_comma, value_str, flags=re.IGNORECASE)
             if match:
                 extracted_plz = match.group(1)
-                value_str = re.sub(plz_pattern_no_comma, '', value_str, flags=re.IGNORECASE)
-        
-        return value_str.strip(), extracted_plz
-    
+                extracted_city = match.group(2).strip()
+                value_str = re.sub(plz_city_no_comma, '', value_str, flags=re.IGNORECASE)
+            else:
+                # Pattern: ", 12345" or " 12345" (PLZ only)
+                plz_only_comma = r',\s*(\d{5})$'
+                match = re.search(plz_only_comma, value_str)
+                if match:
+                    extracted_plz = match.group(1)
+                    value_str = re.sub(plz_only_comma, '', value_str)
+                else:
+                    plz_only_no_comma = r'\s+(\d{5})$'
+                    match = re.search(plz_only_no_comma, value_str)
+                    if match:
+                        extracted_plz = match.group(1)
+                        value_str = re.sub(plz_only_no_comma, '', value_str)
+
+        return value_str.strip(), extracted_plz, extracted_city
+
     # Apply extraction to all values
-    results = series.apply(extract_plz_and_clean)
-    
-    # Separate company names and PLZ
+    results = series.apply(extract_plz_city_and_clean)
+
+    # Separate company names, PLZ, and city
     company_names = pd.Series([result[0] for result in results], index=series.index)
     plz_codes = pd.Series([result[1] for result in results], index=series.index)
-    
-    return company_names, plz_codes
+    city_names = pd.Series([result[2] for result in results], index=series.index)
+
+    return company_names, plz_codes, city_names
 
 
 def clean_company_field(series: pd.Series) -> pd.Series:
@@ -503,7 +518,7 @@ def clean_dataframe(
             progress_callback(10.0)  # Additional 5% for PLZ extraction
 
         _status("Extrahiere Postleitzahlen aus Firmennamen...")
-        company_cleaned, plz_extracted = extract_plz_from_company(cleaned['company'])
+        company_cleaned, plz_extracted, city_extracted = extract_plz_from_company(cleaned['company'])
         cleaned['company'] = company_cleaned
 
         # Add PLZ column (or update if it already exists)
@@ -512,6 +527,17 @@ def clean_dataframe(
         else:
             # If PLZ column exists, only fill empty values
             cleaned['plz'] = cleaned['plz'].fillna(plz_extracted)
+
+        # Use extracted city to correct location if needed
+        if 'location' in cleaned.columns:
+            company_like = r'\b(?:gmbh|mbh|ag|kg|gbr|e\.v\.|generalvikariat)\b'
+            mask = (
+                cleaned['location'].isna()
+                | cleaned['location'].str.contains(company_like, case=False, na=True)
+            ) & city_extracted.notna()
+            cleaned.loc[mask, 'location'] = city_extracted[mask]
+        else:
+            cleaned['location'] = city_extracted
 
         _status(f"PLZ extrahiert: {plz_extracted.notna().sum()} Einträge gefunden")
     

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -220,6 +220,31 @@ def test_clean_dataframe_without_location_column():
         assert cleaned["other"].iloc[2] == "AT&T"
 
 
+def test_clean_dataframe_no_location_column_no_city():
+    """No extracted city should avoid creating a new location column."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch:
+        df = pd.DataFrame({"company": ["Example Corp", "Another Inc"]})
+
+        cleaned = clean_dataframe(df)
+
+        mock_fetch.assert_not_called()
+        assert "location" not in cleaned.columns
+
+
+def test_clean_dataframe_create_location_from_company():
+    """City extracted from company should create location column."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch:
+        mock_fetch.return_value = {}
+
+        df = pd.DataFrame({
+            "company": ["Stadt Münster, 48127 Münster", "Example Corp"]
+        })
+
+        cleaned = clean_dataframe(df)
+
+        assert cleaned["location"].tolist() == ["Münster", None]
+
+
 def test_clean_dataframe_location_from_company():
     """Locations resembling company names should be replaced by cities from company field."""
     with patch('cleaning.fetch_german_license_plates') as mock_fetch:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -220,6 +220,26 @@ def test_clean_dataframe_without_location_column():
         assert cleaned["other"].iloc[2] == "AT&T"
 
 
+def test_clean_dataframe_location_from_company():
+    """Locations resembling company names should be replaced by cities from company field."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch:
+        mock_fetch.return_value = {}
+
+        df = pd.DataFrame(
+            {
+                "company": [
+                    "Stadt Münster, 48127 Münster",
+                    "Stadtbücherei Frankfurt, 60311 Frankfurt am Main",
+                ],
+                "location": ["Bischöfliches Generalvikariat", "MVB GmbH"],
+            }
+        )
+
+        cleaned = clean_dataframe(df)
+
+        assert cleaned["location"].tolist() == ["Münster", "Frankfurt am Main"]
+
+
 def test_extract_jobdescription_info():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
This pull request enhances the company name cleaning process by improving the extraction of postal codes (PLZ) and cities from company names and using this information to correct location fields in the cleaned dataframe. The main changes involve expanding the extraction logic to handle cities, updating the dataframe cleaning workflow to use the extracted city, and adding a new test to verify this behavior.

**Extraction Improvements:**
* The `extract_plz_from_company` function now extracts both postal codes and city names from company names, returning three values: cleaned company name, PLZ, and city. [[1]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL31-R34) [[2]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL41-R94)

**Dataframe Cleaning Workflow:**
* The `clean_dataframe` function is updated to use the extracted city to correct the `location` column, replacing company-like entries or missing values with the city where available, and creating the column if it does not exist. [[1]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL506-R521) [[2]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fR531-R541)

**Testing:**
* A new test, `test_clean_dataframe_location_from_company`, verifies that locations resembling company names are replaced by the extracted city from the company field.