### PR TITLE
Avoid creating empty location column

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -537,7 +537,8 @@ def clean_dataframe(
             ) & city_extracted.notna()
             cleaned.loc[mask, 'location'] = city_extracted[mask]
         else:
-            cleaned['location'] = city_extracted
+            if city_extracted.notna().any():
+                cleaned['location'] = city_extracted
 
         _status(f"PLZ extrahiert: {plz_extracted.notna().sum()} Einträge gefunden")
     

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -220,6 +220,31 @@ def test_clean_dataframe_without_location_column():
         assert cleaned["other"].iloc[2] == "AT&T"
 
 
+def test_clean_dataframe_no_location_column_no_city():
+    """No extracted city should avoid creating a new location column."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch:
+        df = pd.DataFrame({"company": ["Example Corp", "Another Inc"]})
+
+        cleaned = clean_dataframe(df)
+
+        mock_fetch.assert_not_called()
+        assert "location" not in cleaned.columns
+
+
+def test_clean_dataframe_create_location_from_company():
+    """City extracted from company should create location column."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch:
+        mock_fetch.return_value = {}
+
+        df = pd.DataFrame({
+            "company": ["Stadt Münster, 48127 Münster", "Example Corp"]
+        })
+
+        cleaned = clean_dataframe(df)
+
+        assert cleaned["location"].tolist() == ["Münster", None]
+
+
 def test_clean_dataframe_location_from_company():
     """Locations resembling company names should be replaced by cities from company field."""
     with patch('cleaning.fetch_german_license_plates') as mock_fetch:


### PR DESCRIPTION
This pull request improves the handling of the `location` column creation in the `clean_dataframe` function, making the logic more robust when extracting city information from company names. It also adds new tests to cover edge cases related to this behavior.

**Enhancements to location extraction logic:**

* Updated `clean_dataframe` so that the `location` column is only created if at least one city is successfully extracted from company names, preventing unnecessary column creation.

**New and improved tests:**

* Added `test_clean_dataframe_no_location_column_no_city` to verify that no `location` column is created when no city can be extracted.
* Added `test_clean_dataframe_create_location_from_company` to verify that a `location` column is created and populated when a city is extracted from the company field.