### PR TITLE
Add coordinate-based region lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ein Projekt im Rahmen der Hausarbeit im 6. Fachsemester des Studiengangs **Infor
 - **Datenbereinigung**
   - Dekodiert HTML-Entitäten, entfernt Tags und extrahiert Postleitzahlen aus Firmennamen in eine eigene Spalte.
   - Ersetzt Kfz-Kennzeichen durch vollständige Ortsnamen (Wikidata API über `requests` mit lokalem Cache).
-  - Ordnet Orte den Bundesländern zu und erweitert den Datensatz um die Spalte `region` (Mapping aus `ort_bundesland.sql`).
+  - Ordnet Orte den Bundesländern zu und erweitert den Datensatz um die Spalte `region` (Mapping aus `ort_bundesland.sql`, Fallback über `reverse_geocoder` bei vorhandenen Koordinaten).
   - Standardisiert Firmennamen und bereinigt kryptische Werte.
   - Extrahiert Angaben zu Befristung, Arbeitszeit und Vergütung aus dem Attribut `jobdescription` in separate Spalten.
 - **Data Profiling & Reporting**

--- a/cleaning.py
+++ b/cleaning.py
@@ -9,7 +9,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.neighbors import NearestNeighbors
 
 from license_plates import fetch_german_license_plates, resolve_license_plates_in_series
-from region_mapper import match_region_fuzzy, load_region_mapping
+from region_mapper import match_region_fuzzy, load_region_mapping, region_from_coordinates
 from utils import make_status_printer
 
 
@@ -588,6 +588,17 @@ def clean_dataframe(
             cleaned.loc[missing_mask, 'region'] = cleaned.loc[missing_mask, 'location'].apply(
                 lambda loc: match_region_fuzzy(loc, region_mapping)
             )
+        if 'geo_lat' in cleaned.columns and 'geo_lon' in cleaned.columns:
+            coord_mask = (
+                cleaned['region'].isna()
+                & cleaned['geo_lat'].notna()
+                & cleaned['geo_lon'].notna()
+            )
+            if coord_mask.any():
+                cleaned.loc[coord_mask, 'region'] = cleaned.loc[coord_mask, ['geo_lat', 'geo_lon']].apply(
+                    lambda row: region_from_coordinates(row['geo_lat'], row['geo_lon']),
+                    axis=1,
+                )
 
     if progress_callback:
         progress_callback(100.0)

--- a/region_mapper.py
+++ b/region_mapper.py
@@ -6,6 +6,32 @@ from typing import Optional
 import pandas as pd
 from rapidfuzz import process
 
+
+@lru_cache()
+def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
+    """Return German federal state for given ``lat`` and ``lon``.
+
+    Uses the offline :mod:`reverse_geocoder` dataset to map coordinates to the
+    nearest settlement and extracts the ``admin1`` field which corresponds to
+    the Bundesland. Only results within Germany (``cc == 'DE'``) are returned;
+    otherwise ``None`` is yielded. Results are cached to avoid repeated lookups
+    for the same coordinate pair.
+    """
+
+    if pd.isna(lat) or pd.isna(lon):
+        return None
+    try:
+        import reverse_geocoder as rg  # type: ignore
+
+        result = rg.search((float(lat), float(lon)), mode=1)
+    except Exception:
+        return None
+
+    if result and result[0].get("cc") == "DE":
+        return result[0].get("admin1")
+
+    return None
+
 def match_region_fuzzy(location: str, mapping: pd.DataFrame, threshold: int = 90) -> Optional[str]:
     """Return region name for *location* using fuzzy matching.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psycopg2-binary
 PyQt6
 nltk
 requests
+reverse_geocoder

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -372,3 +372,20 @@ def test_region_enrichment_fuzzy():
         assert cleaned.loc[1, "region"] == "Bayern"  # fuzzy match
         assert pd.isna(cleaned.loc[2, "region"])  # no match
 
+
+def test_region_enrichment_coordinates():
+    """Coordinates should resolve to German federal states when names fail."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch:
+        mock_fetch.return_value = {}
+
+        df = pd.DataFrame({
+            "jobid": [19065],
+            "location": ["Uckerland"],
+            "geo_lat": [53.5264244],
+            "geo_lon": [13.8020306],
+        })
+
+        cleaned = clean_dataframe(df)
+
+        assert cleaned.loc[0, "region"] == "Mecklenburg-Vorpommern"
+


### PR DESCRIPTION
This pull request improves the enrichment of the `region` column in the dataset by introducing a fallback mechanism that uses geographic coordinates when location names cannot be mapped to German federal states. The changes add a new utility for mapping coordinates to regions, update the main cleaning logic to use this fallback, and introduce a corresponding test to ensure correctness.

**Region enrichment improvements:**

* Added a new function `region_from_coordinates` in `region_mapper.py` that uses the offline `reverse_geocoder` dataset to map latitude and longitude to the nearest German federal state, with caching for efficiency.
* Updated `cleaning.py` to use `region_from_coordinates` as a fallback for entries where the region could not be determined by name but coordinates are available.
* Modified the import statement in `cleaning.py` to include `region_from_coordinates` from `region_mapper.py`.

**Documentation update:**

* Clarified in `README.md` that region mapping now falls back to using `reverse_geocoder` with coordinates if mapping by name fails.

**Testing:**

* Added a new test in `tests/test_cleaning.py` to verify that coordinates are correctly resolved to German federal states when name-based mapping is unsuccessful.