### PR TITLE
Persist PostgreSQL connection settings

### DIFF
--- a/start.py
+++ b/start.py
@@ -687,6 +687,9 @@ class DataWarehouseWindow(QtWidgets.QDialog):
         self._password.setEchoMode(QtWidgets.QLineEdit.EchoMode.Password)
         self._dbname = QtWidgets.QLineEdit("bibliojobs_dw", self)
 
+        self._settings = QtCore.QSettings("fh-potsdam", "information-integration")
+        self._load_settings()
+
         form.addRow("Host", self._host)
         form.addRow("Port", self._port)
         form.addRow("Benutzer", self._user)
@@ -720,6 +723,8 @@ class DataWarehouseWindow(QtWidgets.QDialog):
             QtWidgets.QMessageBox.critical(self, "Fehler", "Port muss eine Zahl sein")
             return
 
+        self._save_settings(info)
+
         self._create_button.setEnabled(False)
         self._status.show()
         self._progress.show()
@@ -751,6 +756,21 @@ class DataWarehouseWindow(QtWidgets.QDialog):
     def _on_error(self, message: str) -> None:  # pragma: no cover - UI only
         QtWidgets.QMessageBox.critical(self, "Fehler", message)
         self._create_button.setEnabled(True)
+
+    def _load_settings(self) -> None:
+        self._host.setText(self._settings.value("db/host", self._host.text()))
+        self._port.setText(str(self._settings.value("db/port", self._port.text())))
+        self._user.setText(self._settings.value("db/user", ""))
+        self._password.setText(self._settings.value("db/password", ""))
+        self._dbname.setText(self._settings.value("db/dbname", self._dbname.text()))
+
+    def _save_settings(self, info: dict[str, str | int]) -> None:
+        self._settings.setValue("db/host", info["host"])
+        self._settings.setValue("db/port", str(info["port"]))
+        self._settings.setValue("db/user", info["user"])
+        self._settings.setValue("db/password", info["password"])
+        self._settings.setValue("db/dbname", info["dbname"])
+        self._settings.sync()
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Startet die Informationsintegration-GUI")

--- a/tests/test_datawarehouse_window.py
+++ b/tests/test_datawarehouse_window.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+QtWidgets = pytest.importorskip("PyQt6.QtWidgets", exc_type=ImportError)
+from start import DataWarehouseWindow
+
+
+def test_datawarehouse_window_persists_settings(tmp_path) -> None:
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path)
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    df = pd.DataFrame()
+
+    window = DataWarehouseWindow(df)
+    window._host.setText("example.com")
+    window._port.setText("1234")
+    window._user.setText("alice")
+    window._password.setText("secret")
+    window._dbname.setText("mydb")
+    info = {
+        "host": "example.com",
+        "port": 1234,
+        "user": "alice",
+        "password": "secret",
+        "dbname": "mydb",
+    }
+    window._save_settings(info)
+    window.close()
+
+    window2 = DataWarehouseWindow(df)
+    assert window2._host.text() == "example.com"
+    assert window2._port.text() == "1234"
+    assert window2._user.text() == "alice"
+    assert window2._password.text() == "secret"
+    assert window2._dbname.text() == "mydb"
+    window2.close()
+    app.quit()


### PR DESCRIPTION
This pull request adds support for persisting database connection settings in the `DataWarehouseWindow` class. Now, when a user enters their connection details, these settings are saved and automatically loaded the next time the window is opened. This improves usability by eliminating the need to re-enter connection information each time.

**Settings persistence:**

* Added a `QSettings` instance to `DataWarehouseWindow` and methods `_load_settings` and `_save_settings` to manage saving and loading database connection settings (`host`, `port`, `user`, `password`, `dbname`). Settings are loaded on initialization and saved when a connection is created. [[1]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR690-R692) [[2]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR726-R727) [[3]](diffhunk://#diff-2ac3463e100bf40665b1d81741538c3c3f19ddfafed3cd782d5cc6220acfb27fR760-R774)

**Testing:**

* Added a test `test_datawarehouse_window_persists_settings` in `tests/test_datawarehouse_window.py` to verify that settings are correctly saved and loaded between window instances.