### PR TITLE
Embed ER diagram in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ python start.py path/zur/bibliojobs_raw.csv
 pytest
 ```
 
+## ER-Diagramm
+
+![ER-Diagramm des Data Warehouses](er-diagram.png)
+
 ## LaTeX-Dokument
 
 Die schriftliche Ausarbeitung dieses Projekts befindet sich in `main.tex`.

--- a/main.tex
+++ b/main.tex
@@ -21,6 +21,7 @@
 \usepackage{setspace}
 \usepackage[hidelinks]{hyperref}
 \usepackage{csquotes}
+\usepackage{graphicx}
 \usepackage{svg}
 \usepackage[backend=biber,style=authoryear,language=german]{biblatex}
 \addbibresource{refs/refs.bib}
@@ -120,6 +121,13 @@ Nach Abschluss der Bereinigung wird der Button \glqq Dubletten finden\grqq{} fre
 Nachdem mindestens eine Dublette entfernt wurde, blendet die Anwendung einen weiteren Button \glqq Datenbank initialisieren\grqq{} ein. Ein Dialog fragt die Verbindungsdaten inklusive numerischem Port ab und legt auf einem PostgreSQL-Server ein Data Warehouse nach Sternschema an. Dabei entstehen Dimensionstabellen für Unternehmen, Orte und Jobtypen sowie die Faktentabelle \texttt{fact\_job}, die mit dem bereinigten, dublettenfreien Datensatz gefüllt werden. Während des Imports informiert ein Ladebalken mit Statusmeldungen über die aktuellen Schritte, da der Vorgang einige Zeit in Anspruch nehmen kann.
 
 Voraussetzung ist ein laufender PostgreSQL-Server auf dem angegebenen Host und Port. Ist keine Verbindung möglich, weist eine Fehlermeldung auf das Problem hin.
+
+\begin{figure}[h]
+    \centering
+    \includegraphics[width=\textwidth]{er-diagram.png}
+    \caption{ER-Diagramm des Data Warehouses}
+    \label{fig:er-diagram}
+\end{figure}
 
 Zur Benennung der Fehlertypen wurde die Klassifikation von Naumann und Leser genutzt, die in den folgenden beiden Abschnitten beschrieben werden.
 


### PR DESCRIPTION
This pull request introduces documentation improvements to better illustrate the data warehouse structure and support image inclusion in the LaTeX document. The main changes are the addition of an ER diagram to both the `README.md` and the LaTeX documentation, and the inclusion of the necessary package to handle image files in LaTeX.

**Documentation Enhancements:**

* Added an "ER-Diagramm" section to the `README.md`, including a reference to the `er-diagram.png` image to visually represent the data warehouse structure.
* Included the `graphicx` package in `main.tex` to enable image embedding in the LaTeX document.
* Embedded the `er-diagram.png` as a figure in the "Umsetzung" chapter of `main.tex`, complete with caption and label for referencing.