### PR TITLE
Cache fuzzy region matches

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -591,8 +591,14 @@ def clean_dataframe(
         cleaned["region"] = cleaned["location"].map(region_map)
         missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
         if missing_mask.any():
-            cleaned.loc[missing_mask, "region"] = cleaned.loc[missing_mask, "location"].apply(
-                lambda loc: match_region_fuzzy(loc, region_mapping)
+            missing_locations = (
+                cleaned.loc[missing_mask, "location"].dropna().astype(str).unique()
+            )
+            fuzzy_cache = {
+                loc: match_region_fuzzy(loc, region_mapping) for loc in missing_locations
+            }
+            cleaned.loc[missing_mask, "region"] = cleaned.loc[missing_mask, "location"].map(
+                fuzzy_cache
             )
         if "geo_lat" in cleaned.columns and "geo_lon" in cleaned.columns:
             coord_mask = (


### PR DESCRIPTION
This pull request refactors the fuzzy region matching logic in the `_progress` function of `cleaning.py` to improve efficiency. Instead of applying the fuzzy matching function to each missing location individually, it now builds a cache of unique location matches and maps them in bulk.

Performance and efficiency improvements:

* Refactored the fuzzy region matching step to cache results for unique missing locations and use a mapping, reducing redundant calls to `match_region_fuzzy` for repeated values. (`cleaning.py`, [cleaning.pyL594-R601](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL594-R601))