### PR TITLE
Add region job count card to dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,45 @@ from __future__ import annotations
 
 import psycopg2
 from flask import Flask, render_template_string
+from region_mapper import region_from_coordinates
+
+BUNDESLAENDER = [
+    "Baden-Württemberg",
+    "Bayern",
+    "Berlin",
+    "Brandenburg",
+    "Bremen",
+    "Hamburg",
+    "Hessen",
+    "Mecklenburg-Vorpommern",
+    "Niedersachsen",
+    "Nordrhein-Westfalen",
+    "Rheinland-Pfalz",
+    "Saarland",
+    "Sachsen",
+    "Sachsen-Anhalt",
+    "Schleswig-Holstein",
+    "Thüringen",
+]
+
+REGION_MAP = {
+    "Baden-Württemberg": "Baden-Württemberg",
+    "Bavaria": "Bayern",
+    "Berlin": "Berlin",
+    "Brandenburg": "Brandenburg",
+    "Bremen": "Bremen",
+    "Hamburg": "Hamburg",
+    "Hesse": "Hessen",
+    "Mecklenburg-Western Pomerania": "Mecklenburg-Vorpommern",
+    "Lower Saxony": "Niedersachsen",
+    "North Rhine-Westphalia": "Nordrhein-Westfalen",
+    "Rhineland-Palatinate": "Rheinland-Pfalz",
+    "Saarland": "Saarland",
+    "Saxony": "Sachsen",
+    "Saxony-Anhalt": "Sachsen-Anhalt",
+    "Schleswig-Holstein": "Schleswig-Holstein",
+    "Thuringia": "Thüringen",
+}
 
 TEMPLATE = """
 <!DOCTYPE html>
@@ -29,6 +68,21 @@ TEMPLATE = """
                     <div class="card-body">
                         <h5 class="card-title">Insttype Verteilung</h5>
                         <canvas id="instChart"></canvas>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">Stellen nach Bundesland</h5>
+                        <ul class="list-group list-group-flush">
+                            {% for region, count in regions %}
+                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                {{ region }}
+                                <span class="badge bg-primary rounded-pill">{{ count }}</span>
+                            </li>
+                            {% endfor %}
+                        </ul>
                     </div>
                 </div>
             </div>
@@ -78,6 +132,13 @@ def create_app(conn_info: dict[str, str | int]) -> Flask:
                GROUP BY dc.insttype"""
         )
         rows = cur.fetchall()
+        cur.execute(
+            """SELECT dl.geo_lat, dl.geo_lon, COUNT(*)
+               FROM dim_location dl
+               JOIN fact_job fj ON dl.location_id = fj.location_id
+               GROUP BY dl.geo_lat, dl.geo_lon"""
+        )
+        location_rows = cur.fetchall()
         cur.close()
         conn.close()
         labels = []
@@ -87,6 +148,20 @@ def create_app(conn_info: dict[str, str | int]) -> Flask:
             counts.append(count)
         sum_counts = sum(counts) or 1
         labels = [f"{label} ({count / sum_counts * 100:.1f}%)" for label, count in zip(labels, counts)]
-        return render_template_string(TEMPLATE, total=total, labels=labels, counts=counts)
+        region_counts = {bl: 0 for bl in BUNDESLAENDER}
+        unknown = 0
+        for lat, lon, count in location_rows:
+            region = region_from_coordinates(lat, lon)
+            region = REGION_MAP.get(region)
+            if region in region_counts:
+                region_counts[region] += count
+            else:
+                unknown += count
+        regions = [(bl, region_counts[bl]) for bl in BUNDESLAENDER]
+        if unknown:
+            regions.append(("Unbekannt", unknown))
+        return render_template_string(
+            TEMPLATE, total=total, labels=labels, counts=counts, regions=regions
+        )
 
     return app

--- a/dashboard.py
+++ b/dashboard.py
@@ -151,10 +151,10 @@ def create_app(conn_info: dict[str, str | int]) -> Flask:
         region_counts = {bl: 0 for bl in BUNDESLAENDER}
         unknown = 0
         for lat, lon, count in location_rows:
-            region = region_from_coordinates(lat, lon)
-            region = REGION_MAP.get(region)
-            if region in region_counts:
-                region_counts[region] += count
+            region_name = region_from_coordinates(lat, lon)
+            region_name = REGION_MAP.get(region_name) if region_name is not None else None
+            if region_name in region_counts:
+                region_counts[region_name] += count
             else:
                 unknown += count
         regions = [(bl, region_counts[bl]) for bl in BUNDESLAENDER]

--- a/dashboard.py
+++ b/dashboard.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import psycopg2
 from flask import Flask, render_template_string
-from region_mapper import region_from_coordinates
 
 BUNDESLAENDER = [
     "Baden-Württemberg",
@@ -23,24 +22,6 @@ BUNDESLAENDER = [
     "Thüringen",
 ]
 
-REGION_MAP = {
-    "Baden-Württemberg": "Baden-Württemberg",
-    "Bavaria": "Bayern",
-    "Berlin": "Berlin",
-    "Brandenburg": "Brandenburg",
-    "Bremen": "Bremen",
-    "Hamburg": "Hamburg",
-    "Hesse": "Hessen",
-    "Mecklenburg-Western Pomerania": "Mecklenburg-Vorpommern",
-    "Lower Saxony": "Niedersachsen",
-    "North Rhine-Westphalia": "Nordrhein-Westfalen",
-    "Rhineland-Palatinate": "Rheinland-Pfalz",
-    "Saarland": "Saarland",
-    "Saxony": "Sachsen",
-    "Saxony-Anhalt": "Sachsen-Anhalt",
-    "Schleswig-Holstein": "Schleswig-Holstein",
-    "Thuringia": "Thüringen",
-}
 
 TEMPLATE = """
 <!DOCTYPE html>
@@ -133,12 +114,12 @@ def create_app(conn_info: dict[str, str | int]) -> Flask:
         )
         rows = cur.fetchall()
         cur.execute(
-            """SELECT dl.geo_lat, dl.geo_lon, COUNT(*)
+            """SELECT dl.region, COUNT(*)
                FROM dim_location dl
                JOIN fact_job fj ON dl.location_id = fj.location_id
-               GROUP BY dl.geo_lat, dl.geo_lon"""
+               GROUP BY dl.region"""
         )
-        location_rows = cur.fetchall()
+        region_rows = cur.fetchall()
         cur.close()
         conn.close()
         labels = []
@@ -150,9 +131,7 @@ def create_app(conn_info: dict[str, str | int]) -> Flask:
         labels = [f"{label} ({count / sum_counts * 100:.1f}%)" for label, count in zip(labels, counts)]
         region_counts = {bl: 0 for bl in BUNDESLAENDER}
         unknown = 0
-        for lat, lon, count in location_rows:
-            region_name = region_from_coordinates(lat, lon)
-            region_name = REGION_MAP.get(region_name) if region_name is not None else None
+        for region_name, count in region_rows:
             if region_name in region_counts:
                 region_counts[region_name] += count
             else:

--- a/data_warehouse.py
+++ b/data_warehouse.py
@@ -77,7 +77,8 @@ def create_data_warehouse(
             country TEXT,
             geo_lat DOUBLE PRECISION,
             geo_lon DOUBLE PRECISION,
-            plz TEXT
+            plz TEXT,
+            region TEXT
         )
         """
     )
@@ -109,7 +110,7 @@ def create_data_warehouse(
 
     # Populate dimension tables
     company_df = df[["company", "insttype"]].drop_duplicates().reset_index(drop=True)
-    location_df = df[["location", "country", "geo_lat", "geo_lon", "plz"]].drop_duplicates().reset_index(drop=True)
+    location_df = df[["location", "country", "geo_lat", "geo_lon", "plz", "region"]].drop_duplicates().reset_index(drop=True)
     jobtype_df = df[["jobtype"]].drop_duplicates().reset_index(drop=True)
     total_rows = len(company_df) + len(location_df) + len(jobtype_df) + len(df)
     processed = 0
@@ -133,21 +134,22 @@ def create_data_warehouse(
     _status("Fülle Orte ...")
     for _, row in location_df.iterrows():
         cur.execute(
-            """INSERT INTO dim_location (location, country, geo_lat, geo_lon, plz)
-            VALUES (%s, %s, %s, %s, %s)""",
+            """INSERT INTO dim_location (location, country, geo_lat, geo_lon, plz, region)
+            VALUES (%s, %s, %s, %s, %s, %s)""",
             (
                 row.get("location"),
                 row.get("country"),
                 row.get("geo_lat"),
                 row.get("geo_lon"),
                 row.get("plz"),
+                row.get("region"),
             ),
         )
         processed += 1
         _update_progress()
     conn.commit()
     cur.execute(
-        "SELECT location_id, location, country, geo_lat, geo_lon, plz FROM dim_location"
+        "SELECT location_id, location, country, geo_lat, geo_lon, plz, region FROM dim_location"
     )
     location_map = {(r[1], r[2], r[3], r[4], r[5]): r[0] for r in cur.fetchall()}
 


### PR DESCRIPTION
This pull request introduces enhancements to both the data warehouse and dashboard, enabling the aggregation and display of job counts by German federal state ("Bundesland"). The changes add a new `region` field to the location dimension, update data ingestion to handle this field, and extend the dashboard to visualize jobs per region.

**Data warehouse schema and ingestion updates:**

* Added a new `region` column to the `dim_location` table schema and updated all relevant SQL statements and dataframes to include this field. [[1]](diffhunk://#diff-ba4cb085105db0489566a253d4e3cab71f0d03b299b33904e23a657406176323L80-R81) [[2]](diffhunk://#diff-ba4cb085105db0489566a253d4e3cab71f0d03b299b33904e23a657406176323L112-R113) [[3]](diffhunk://#diff-ba4cb085105db0489566a253d4e3cab71f0d03b299b33904e23a657406176323L136-R152)

**Dashboard enhancements:**

* Introduced the `BUNDESLAENDER` list in `dashboard.py` to define all German federal states for consistent display and aggregation.
* Added a new dashboard section that displays job counts per Bundesland, using data queried from the updated schema. [[1]](diffhunk://#diff-0b33aef4b18b18a32444e65bdef64f6431c2e6cf844a820cf75ae09a73bcf535R55-R69) [[2]](diffhunk://#diff-0b33aef4b18b18a32444e65bdef64f6431c2e6cf844a820cf75ae09a73bcf535R116-R122) [[3]](diffhunk://#diff-0b33aef4b18b18a32444e65bdef64f6431c2e6cf844a820cf75ae09a73bcf535L90-R144)