### PR TITLE
Fix region mapping for ambiguous locations

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -587,16 +587,47 @@ def clean_dataframe(
 
     if region_mapping is not None and "location" in cleaned.columns:
         _status("Bestimme Regionen...")
-        # Remove ambiguous location entries where multiple regions exist
+        cleaned["region"] = None
+
+        # 1) exact coordinate mapping using SQL dump
+        if {
+            "geo_lat",
+            "geo_lon",
+        }.issubset(cleaned.columns) and {
+            "geo_lat",
+            "geo_lon",
+        }.issubset(region_mapping.columns):
+            coord_map = (
+                region_mapping.dropna(subset=["geo_lat", "geo_lon"])
+                .assign(
+                    geo_lat=lambda df: df["geo_lat"].round(4),
+                    geo_lon=lambda df: df["geo_lon"].round(4),
+                )
+                .drop_duplicates(["geo_lat", "geo_lon"])
+                .set_index(["geo_lat", "geo_lon"])["region"]
+            )
+            cleaned["region"] = [
+                coord_map.get((lat, lon))
+                for lat, lon in zip(
+                    cleaned["geo_lat"].round(4), cleaned["geo_lon"].round(4)
+                )
+            ]
+
+        # 2) match by location if still missing
         region_counts = region_mapping.groupby("location")["region"].nunique()
         ambiguous_locations = region_counts[region_counts > 1].index
         unique_mapping = region_mapping[~region_mapping["location"].isin(ambiguous_locations)]
-
-        region_map = (
+        location_map = (
             unique_mapping.drop_duplicates("location").set_index("location")["region"]
         )
-        cleaned["region"] = cleaned["location"].map(region_map)
 
+        missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
+        if missing_mask.any():
+            cleaned.loc[missing_mask, "region"] = cleaned.loc[
+                missing_mask, "location"
+            ].map(location_map)
+
+        # optional fuzzy matching for remaining
         missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
         if missing_mask.any():
             missing_locations = (
@@ -605,11 +636,12 @@ def clean_dataframe(
             fuzzy_cache = {
                 loc: match_region_fuzzy(loc, unique_mapping) for loc in missing_locations
             }
-            cleaned.loc[missing_mask, "region"] = cleaned.loc[missing_mask, "location"].map(
-                fuzzy_cache
-            )
+            cleaned.loc[missing_mask, "region"] = cleaned.loc[
+                missing_mask, "location"
+            ].map(fuzzy_cache)
 
-        if "geo_lat" in cleaned.columns and "geo_lon" in cleaned.columns:
+        # 3) API fallback using coordinates
+        if {"geo_lat", "geo_lon"}.issubset(cleaned.columns):
             coord_mask = (
                 cleaned["region"].isna()
                 & cleaned["geo_lat"].notna()
@@ -619,7 +651,9 @@ def clean_dataframe(
                 cleaned.loc[coord_mask, "region"] = cleaned.loc[
                     coord_mask, ["geo_lat", "geo_lon"]
                 ].apply(
-                    lambda row: region_from_coordinates(row["geo_lat"], row["geo_lon"]),
+                    lambda row: region_from_coordinates(
+                        row["geo_lat"], row["geo_lon"]
+                    ),
                     axis=1,
                 )
 

--- a/cleaning.py
+++ b/cleaning.py
@@ -587,19 +587,28 @@ def clean_dataframe(
 
     if region_mapping is not None and "location" in cleaned.columns:
         _status("Bestimme Regionen...")
-        region_map = region_mapping.drop_duplicates("location").set_index("location")["region"]
+        # Remove ambiguous location entries where multiple regions exist
+        region_counts = region_mapping.groupby("location")["region"].nunique()
+        ambiguous_locations = region_counts[region_counts > 1].index
+        unique_mapping = region_mapping[~region_mapping["location"].isin(ambiguous_locations)]
+
+        region_map = (
+            unique_mapping.drop_duplicates("location").set_index("location")["region"]
+        )
         cleaned["region"] = cleaned["location"].map(region_map)
+
         missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
         if missing_mask.any():
             missing_locations = (
                 cleaned.loc[missing_mask, "location"].dropna().astype(str).unique()
             )
             fuzzy_cache = {
-                loc: match_region_fuzzy(loc, region_mapping) for loc in missing_locations
+                loc: match_region_fuzzy(loc, unique_mapping) for loc in missing_locations
             }
             cleaned.loc[missing_mask, "region"] = cleaned.loc[missing_mask, "location"].map(
                 fuzzy_cache
             )
+
         if "geo_lat" in cleaned.columns and "geo_lon" in cleaned.columns:
             coord_mask = (
                 cleaned["region"].isna()

--- a/cleaning.py
+++ b/cleaning.py
@@ -4,12 +4,12 @@ import time
 from typing import Any, Callable, Optional
 
 import pandas as pd
-from rapidfuzz import fuzz
+from rapidfuzz import fuzz, process
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.neighbors import NearestNeighbors
 
 from license_plates import fetch_german_license_plates, resolve_license_plates_in_series
-from region_mapper import match_region_fuzzy, load_region_mapping, region_from_coordinates
+from region_mapper import load_region_mapping, region_from_coordinates
 from utils import make_status_printer
 
 
@@ -622,9 +622,15 @@ def clean_dataframe(
             location_groups = {
                 loc: grp for loc, grp in region_mapping.groupby("location")
             }
+            all_locations = list(location_groups.keys())
 
             def _resolve_location(row):
-                group = location_groups.get(row["location"])
+                loc = row["location"]
+                group = location_groups.get(loc)
+                if group is None:
+                    match = process.extractOne(str(loc), all_locations, score_cutoff=90)
+                    if match:
+                        group = location_groups.get(match[0])
                 if group is None:
                     return None
                 if len(group) == 1:
@@ -647,25 +653,6 @@ def clean_dataframe(
                 cleaned.loc[missing_mask, "region"] = cleaned.loc[missing_mask].apply(
                     _resolve_location, axis=1
                 )
-
-            # optional fuzzy matching for remaining using unique mapping
-            region_counts = region_mapping.groupby("location")["region"].nunique()
-            ambiguous_locations = region_counts[region_counts > 1].index
-            unique_mapping = region_mapping[
-                ~region_mapping["location"].isin(ambiguous_locations)
-            ]
-
-            missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
-            if missing_mask.any():
-                missing_locations = (
-                    cleaned.loc[missing_mask, "location"].dropna().astype(str).unique()
-                )
-                fuzzy_cache = {
-                    loc: match_region_fuzzy(loc, unique_mapping) for loc in missing_locations
-                }
-                cleaned.loc[missing_mask, "region"] = cleaned.loc[
-                    missing_mask, "location"
-                ].map(fuzzy_cache)
 
     # 3) API fallback using coordinates
     if {"geo_lat", "geo_lon"}.issubset(cleaned.columns):

--- a/cleaning.py
+++ b/cleaning.py
@@ -483,6 +483,7 @@ def clean_dataframe(
     progress_callback: Optional[Callable[[float], None]] = None,
     status_callback: Optional[Callable[[str], None]] = None,
     region_mapping: Optional[pd.DataFrame] = None,
+    debug: bool = False,
 ) -> pd.DataFrame:
     """Return a cleaned copy of *df* with HTML entities decoded, tags removed,
     license plates resolved, company names standardized, and PLZ extracted to separate column.
@@ -681,6 +682,29 @@ def clean_dataframe(
                     row["geo_lat"], row["geo_lon"]
                 ),
                 axis=1,
+            )
+
+    if debug:
+        missing_region = cleaned[cleaned["region"].isna()]
+        for _, row in missing_region.iterrows():
+            reasons: list[str] = []
+            loc_val = row.get("location")
+            if pd.isna(loc_val) or str(loc_val).strip() == "":
+                reasons.append("missing location")
+            if pd.isna(row.get("geo_lat")) or pd.isna(row.get("geo_lon")):
+                reasons.append("missing coordinates")
+            else:
+                reasons.append("no region match or API failure")
+            jobid = row.get("jobid", _)
+            print(
+                "[region debug] jobid=%s location=%s lat=%s lon=%s reason=%s"
+                % (
+                    jobid,
+                    loc_val,
+                    row.get("geo_lat"),
+                    row.get("geo_lon"),
+                    ", ".join(reasons) if reasons else "unknown",
+                )
             )
 
     _progress(100.0)

--- a/cleaning.py
+++ b/cleaning.py
@@ -578,16 +578,19 @@ def clean_dataframe(
     _progress(90.0)
 
     # Enrich with region information
-    if region_mapping is None and "location" in cleaned.columns:
-        _status("Lade Regionszuordnung...")
+    if region_mapping is None:
+        if _status:
+            _status("Lade Regionszuordnung...")
         try:
             region_mapping = load_region_mapping()
         except FileNotFoundError:
             region_mapping = None
 
-    if region_mapping is not None and "location" in cleaned.columns:
-        _status("Bestimme Regionen...")
+    if "region" not in cleaned.columns:
         cleaned["region"] = None
+
+    if region_mapping is not None:
+        _status("Bestimme Regionen...")
 
         # 1) exact coordinate mapping using SQL dump
         if {
@@ -614,7 +617,7 @@ def clean_dataframe(
             ]
 
         # 2) match by location if still missing
-        if "location" in region_mapping.columns:
+        if "location" in cleaned.columns and "location" in region_mapping.columns:
             location_groups = {
                 loc: grp for loc, grp in region_mapping.groupby("location")
             }
@@ -663,22 +666,22 @@ def clean_dataframe(
                     missing_mask, "location"
                 ].map(fuzzy_cache)
 
-        # 3) API fallback using coordinates
-        if {"geo_lat", "geo_lon"}.issubset(cleaned.columns):
-            coord_mask = (
-                cleaned["region"].isna()
-                & cleaned["geo_lat"].notna()
-                & cleaned["geo_lon"].notna()
+    # 3) API fallback using coordinates
+    if {"geo_lat", "geo_lon"}.issubset(cleaned.columns):
+        coord_mask = (
+            cleaned["region"].isna()
+            & cleaned["geo_lat"].notna()
+            & cleaned["geo_lon"].notna()
+        )
+        if coord_mask.any():
+            cleaned.loc[coord_mask, "region"] = cleaned.loc[
+                coord_mask, ["geo_lat", "geo_lon"]
+            ].apply(
+                lambda row: region_from_coordinates(
+                    row["geo_lat"], row["geo_lon"]
+                ),
+                axis=1,
             )
-            if coord_mask.any():
-                cleaned.loc[coord_mask, "region"] = cleaned.loc[
-                    coord_mask, ["geo_lat", "geo_lon"]
-                ].apply(
-                    lambda row: region_from_coordinates(
-                        row["geo_lat"], row["geo_lon"]
-                    ),
-                    axis=1,
-                )
 
     _progress(100.0)
     return cleaned

--- a/cleaning.py
+++ b/cleaning.py
@@ -593,7 +593,7 @@ def clean_dataframe(
     if region_mapping is not None:
         _status("Bestimme Regionen...")
 
-        # 1) exact coordinate mapping using SQL dump
+        # 1) coordinate-based lookup using nearest neighbours
         if {
             "geo_lat",
             "geo_lon",
@@ -601,21 +601,20 @@ def clean_dataframe(
             "geo_lat",
             "geo_lon",
         }.issubset(region_mapping.columns):
-            coord_map = (
-                region_mapping.dropna(subset=["geo_lat", "geo_lon"])
-                .assign(
-                    geo_lat=lambda df: df["geo_lat"].round(4),
-                    geo_lon=lambda df: df["geo_lon"].round(4),
-                )
-                .drop_duplicates(["geo_lat", "geo_lon"])
-                .set_index(["geo_lat", "geo_lon"])["region"]
-            )
-            cleaned["region"] = [
-                coord_map.get((lat, lon))
-                for lat, lon in zip(
-                    cleaned["geo_lat"].round(4), cleaned["geo_lon"].round(4)
-                )
-            ]
+            mapping_coords = region_mapping.dropna(subset=["geo_lat", "geo_lon"])
+            if not mapping_coords.empty:
+                nbrs = NearestNeighbors(n_neighbors=1)
+                nbrs.fit(mapping_coords[["geo_lat", "geo_lon"]])
+                coord_mask = cleaned["geo_lat"].notna() & cleaned["geo_lon"].notna()
+                if coord_mask.any():
+                    distances, indices = nbrs.kneighbors(
+                        cleaned.loc[coord_mask, ["geo_lat", "geo_lon"]]
+                    )
+                    regions = mapping_coords.reset_index(drop=True)
+                    cleaned.loc[coord_mask, "region"] = [
+                        regions.iloc[idx]["region"] if dist <= 0.005 else None
+                        for dist, idx in zip(distances.ravel(), indices.ravel())
+                    ]
 
         # 2) match by location if still missing
         if "location" in cleaned.columns and "location" in region_mapping.columns:
@@ -628,7 +627,7 @@ def clean_dataframe(
                 loc = row["location"]
                 group = location_groups.get(loc)
                 if group is None:
-                    match = process.extractOne(str(loc), all_locations, score_cutoff=90)
+                    match = process.extractOne(str(loc), all_locations, processor=None, score_cutoff=90)
                     if match:
                         group = location_groups.get(match[0])
                 if group is None:

--- a/cleaning.py
+++ b/cleaning.py
@@ -614,31 +614,54 @@ def clean_dataframe(
             ]
 
         # 2) match by location if still missing
-        region_counts = region_mapping.groupby("location")["region"].nunique()
-        ambiguous_locations = region_counts[region_counts > 1].index
-        unique_mapping = region_mapping[~region_mapping["location"].isin(ambiguous_locations)]
-        location_map = (
-            unique_mapping.drop_duplicates("location").set_index("location")["region"]
-        )
-
-        missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
-        if missing_mask.any():
-            cleaned.loc[missing_mask, "region"] = cleaned.loc[
-                missing_mask, "location"
-            ].map(location_map)
-
-        # optional fuzzy matching for remaining
-        missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
-        if missing_mask.any():
-            missing_locations = (
-                cleaned.loc[missing_mask, "location"].dropna().astype(str).unique()
-            )
-            fuzzy_cache = {
-                loc: match_region_fuzzy(loc, unique_mapping) for loc in missing_locations
+        if "location" in region_mapping.columns:
+            location_groups = {
+                loc: grp for loc, grp in region_mapping.groupby("location")
             }
-            cleaned.loc[missing_mask, "region"] = cleaned.loc[
-                missing_mask, "location"
-            ].map(fuzzy_cache)
+
+            def _resolve_location(row):
+                group = location_groups.get(row["location"])
+                if group is None:
+                    return None
+                if len(group) == 1:
+                    return group.iloc[0]["region"]
+                if {
+                    "geo_lat",
+                    "geo_lon",
+                }.issubset(group.columns) and pd.notna(row.get("geo_lat")) and pd.notna(
+                    row.get("geo_lon")
+                ):
+                    distances = (
+                        (group["geo_lat"] - row["geo_lat"]) ** 2
+                        + (group["geo_lon"] - row["geo_lon"]) ** 2
+                    )
+                    return group.loc[distances.idxmin(), "region"]
+                return None
+
+            missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
+            if missing_mask.any():
+                cleaned.loc[missing_mask, "region"] = cleaned.loc[missing_mask].apply(
+                    _resolve_location, axis=1
+                )
+
+            # optional fuzzy matching for remaining using unique mapping
+            region_counts = region_mapping.groupby("location")["region"].nunique()
+            ambiguous_locations = region_counts[region_counts > 1].index
+            unique_mapping = region_mapping[
+                ~region_mapping["location"].isin(ambiguous_locations)
+            ]
+
+            missing_mask = cleaned["region"].isna() & cleaned["location"].notna()
+            if missing_mask.any():
+                missing_locations = (
+                    cleaned.loc[missing_mask, "location"].dropna().astype(str).unique()
+                )
+                fuzzy_cache = {
+                    loc: match_region_fuzzy(loc, unique_mapping) for loc in missing_locations
+                }
+                cleaned.loc[missing_mask, "region"] = cleaned.loc[
+                    missing_mask, "location"
+                ].map(fuzzy_cache)
 
         # 3) API fallback using coordinates
         if {"geo_lat", "geo_lon"}.issubset(cleaned.columns):

--- a/region_mapper.py
+++ b/region_mapper.py
@@ -64,9 +64,16 @@ def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
     if pd.isna(lat) or pd.isna(lon):
         return None
 
-    params = {"lat": float(lat), "lon": float(lon), "format": "json", "zoom": 3}
+    params = {
+        "lat": float(lat),
+        "lon": float(lon),
+        "format": "json",
+        "zoom": 5,
+        "addressdetails": 1,
+        "email": "info@example.com",
+    }
     headers = {
-        "User-Agent": "information-integration/1.0",
+        "User-Agent": "information-integration/1.0 (info@example.com)",
         "Accept-Language": "de",
     }
 
@@ -97,7 +104,7 @@ def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
     try:
         response = requests.get(
             "https://geocode.maps.co/reverse",
-            params={"lat": float(lat), "lon": float(lon)},
+            params={"lat": float(lat), "lon": float(lon), "format": "json"},
             headers=headers,
             timeout=10,
         )

--- a/region_mapper.py
+++ b/region_mapper.py
@@ -70,6 +70,7 @@ def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
         "Accept-Language": "de",
     }
 
+    region = None
     for _ in range(2):  # allow a single retry on HTTP 429/503
         try:
             _throttle_nominatim()
@@ -84,10 +85,32 @@ def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
                 continue
             if response.ok:
                 data = response.json()
-                return _normalize_region(data.get("address", {}).get("state"))
+                region = _normalize_region(data.get("address", {}).get("state"))
+            break
         except Exception:
-            return None
-    return None
+            break
+
+    if region:
+        return region
+
+    # Fallback service if Nominatim fails or returns no region
+    try:
+        response = requests.get(
+            "https://geocode.maps.co/reverse",
+            params={"lat": float(lat), "lon": float(lon)},
+            headers=headers,
+            timeout=10,
+        )
+        if response.ok:
+            data = response.json()
+            region = _normalize_region(
+                data.get("address", {}).get("state")
+                or data.get("state")
+                or data.get("region")
+            )
+    except Exception:
+        pass
+    return region
 
 def match_region_fuzzy(location: str, mapping: pd.DataFrame, threshold: int = 90) -> Optional[str]:
     """Return region name for *location* using fuzzy matching.

--- a/region_mapper.py
+++ b/region_mapper.py
@@ -4,31 +4,35 @@ from functools import lru_cache
 from typing import Optional
 
 import pandas as pd
+import requests
 from rapidfuzz import process
 
 
 @lru_cache()
 def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
-    """Return German federal state for given ``lat`` and ``lon``.
+    """Return German federal state for given ``lat`` and ``lon`` using an API.
 
-    Uses the offline :mod:`reverse_geocoder` dataset to map coordinates to the
-    nearest settlement and extracts the ``admin1`` field which corresponds to
-    the Bundesland. Only results within Germany (``cc == 'DE'``) are returned;
-    otherwise ``None`` is yielded. Results are cached to avoid repeated lookups
-    for the same coordinate pair.
+    Queries the public Nominatim API which returns address details for the
+    provided coordinates. The ``state`` field is used as Bundesland. Results are
+    cached to avoid repeated lookups for identical coordinate pairs. Network
+    errors or missing data result in ``None``.
     """
 
     if pd.isna(lat) or pd.isna(lon):
         return None
-    try:
-        import reverse_geocoder as rg  # type: ignore
 
-        result = rg.search((float(lat), float(lon)), mode=1)
+    try:
+        response = requests.get(
+            "https://nominatim.openstreetmap.org/reverse",
+            params={"lat": float(lat), "lon": float(lon), "format": "json", "zoom": 3},
+            headers={"User-Agent": "information-integration/1.0"},
+            timeout=10,
+        )
+        if response.ok:
+            data = response.json()
+            return data.get("address", {}).get("state")
     except Exception:
         return None
-
-    if result and result[0].get("cc") == "DE":
-        return result[0].get("admin1")
 
     return None
 
@@ -84,12 +88,26 @@ def load_region_mapping(path: str | Path = Path(__file__).with_name("ort_bundesl
         DataFrame with columns ``location`` and ``region``.
     """
 
-    pattern = re.compile(r"\('([^']*)',\s*'([^']*)'")
+    pattern = re.compile(
+        r"\('([^']*)',\s*'([^']*)',\s*'([^']*)',\s*'([^']*)'"
+    )
     records = []
     with Path(path).open(encoding="utf-8") as fh:
         for line in fh:
-            for name, region in pattern.findall(line):
-                records.append({"location": name, "region": region})
+            for name, region, lat, lon in pattern.findall(line):
+                try:
+                    lat_f = float(lat)
+                    lon_f = float(lon)
+                except ValueError:
+                    continue
+                records.append(
+                    {
+                        "location": name,
+                        "region": region,
+                        "geo_lat": lat_f,
+                        "geo_lon": lon_f,
+                    }
+                )
 
     return pd.DataFrame(records)
 

--- a/region_mapper.py
+++ b/region_mapper.py
@@ -8,6 +8,33 @@ import requests
 from rapidfuzz import process
 
 
+# Some state names in the SQL dump or API responses use English
+# descriptions such as ``"State of Berlin"``.  Normalize those to the
+# short German names used elsewhere in the project.
+REGION_ALIASES = {
+    "State of Berlin": "Berlin",
+}
+
+
+def _normalize_region(region: Optional[str]) -> Optional[str]:
+    """Return a standardized region name or ``None``.
+
+    Parameters
+    ----------
+    region:
+        Original region name which might contain English descriptors.
+
+    Returns
+    -------
+    Optional[str]
+        Normalized region name.
+    """
+
+    if region is None:
+        return None
+    return REGION_ALIASES.get(region, region)
+
+
 @lru_cache()
 def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
     """Return German federal state for given ``lat`` and ``lon`` using an API.
@@ -30,7 +57,7 @@ def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
         )
         if response.ok:
             data = response.json()
-            return data.get("address", {}).get("state")
+            return _normalize_region(data.get("address", {}).get("state"))
     except Exception:
         return None
 
@@ -103,7 +130,7 @@ def load_region_mapping(path: str | Path = Path(__file__).with_name("ort_bundesl
                 records.append(
                     {
                         "location": name,
-                        "region": region,
+                        "region": _normalize_region(region),
                         "geo_lat": lat_f,
                         "geo_lon": lon_f,
                     }

--- a/region_mapper.py
+++ b/region_mapper.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import re
+import time
 from functools import lru_cache
 from typing import Optional
 
@@ -14,6 +15,19 @@ from rapidfuzz import process
 REGION_ALIASES = {
     "State of Berlin": "Berlin",
 }
+
+
+_last_nominatim_call = 0.0
+
+
+def _throttle_nominatim(min_interval: float = 1.0) -> None:
+    """Ensure at most one Nominatim request per ``min_interval`` seconds."""
+
+    global _last_nominatim_call
+    elapsed = time.monotonic() - _last_nominatim_call
+    if elapsed < min_interval:
+        time.sleep(min_interval - elapsed)
+    _last_nominatim_call = time.monotonic()
 
 
 def _normalize_region(region: Optional[str]) -> Optional[str]:
@@ -42,25 +56,37 @@ def region_from_coordinates(lat: float, lon: float) -> Optional[str]:
     Queries the public Nominatim API which returns address details for the
     provided coordinates. The ``state`` field is used as Bundesland. Results are
     cached to avoid repeated lookups for identical coordinate pairs. Network
-    errors or missing data result in ``None``.
+    errors or missing data result in ``None``. The function adheres to the
+    service's usage policy by issuing at most one request per second and
+    retrying once if the service signals rate limiting.
     """
 
     if pd.isna(lat) or pd.isna(lon):
         return None
 
-    try:
-        response = requests.get(
-            "https://nominatim.openstreetmap.org/reverse",
-            params={"lat": float(lat), "lon": float(lon), "format": "json", "zoom": 3},
-            headers={"User-Agent": "information-integration/1.0"},
-            timeout=10,
-        )
-        if response.ok:
-            data = response.json()
-            return _normalize_region(data.get("address", {}).get("state"))
-    except Exception:
-        return None
+    params = {"lat": float(lat), "lon": float(lon), "format": "json", "zoom": 3}
+    headers = {
+        "User-Agent": "information-integration/1.0",
+        "Accept-Language": "de",
+    }
 
+    for _ in range(2):  # allow a single retry on HTTP 429/503
+        try:
+            _throttle_nominatim()
+            response = requests.get(
+                "https://nominatim.openstreetmap.org/reverse",
+                params=params,
+                headers=headers,
+                timeout=10,
+            )
+            if response.status_code in {429, 503}:
+                time.sleep(1)
+                continue
+            if response.ok:
+                data = response.json()
+                return _normalize_region(data.get("address", {}).get("state"))
+        except Exception:
+            return None
     return None
 
 def match_region_fuzzy(location: str, mapping: pd.DataFrame, threshold: int = 90) -> Optional[str]:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -465,3 +465,29 @@ def test_region_api_fallback_without_location_column():
         mock_fetch.assert_not_called()
         mock_coords.assert_called_once()
 
+
+def test_region_api_fallback_with_unmapped_location():
+    """Fallback API should run when location is unmapped but coordinates exist."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
+         patch('cleaning.load_region_mapping') as mock_mapping, \
+         patch('cleaning.region_from_coordinates') as mock_coords:
+        mock_fetch.return_value = {}
+        mock_mapping.return_value = pd.DataFrame({
+            'location': ['Hamburg'],
+            'region': ['Hamburg'],
+            'geo_lat': [53.55],
+            'geo_lon': [10.0],
+        })
+        mock_coords.return_value = 'Berlin'
+
+        df = pd.DataFrame({
+            'location': ['Unbekannt'],
+            'geo_lat': [52.52],
+            'geo_lon': [13.405],
+        })
+
+        cleaned = clean_dataframe(df)
+
+        assert cleaned.loc[0, 'region'] == 'Berlin'
+        mock_coords.assert_called_once()
+

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -492,29 +492,40 @@ def test_region_api_fallback_with_unmapped_location():
         mock_coords.assert_called_once()
 
 
-def test_region_api_fallback_real_world_examples():
-    """Problematic rows from the raw dataset should resolve via API fallback."""
-    rows = [
-        (12365, "Frankenthal (Pfalz)", 49.5340652, 8.3520517, "Rheinland-Pfalz"),
-        (13446, "Frankenberg (Eder)", 51.0545654, 8.7891808, "Hessen"),
-        (13504, "Gronau (Westfalen)", 52.2109108, 7.0228, "Nordrhein-Westfalen"),
-        (13544, "Stolberg (Rheinland)", 50.7891808, 6.2235961, "Nordrhein-Westfalen"),
-    ]
-    df = pd.DataFrame(rows, columns=["jobid", "location", "geo_lat", "geo_lon", "expected"])
-
-    def side_effect(lat, lon):
-        lat = float(lat)
-        lon = float(lon)
-        for _, row in df.iterrows():
-            if abs(row.geo_lat - lat) < 1e-6 and abs(row.geo_lon - lon) < 1e-6:
-                return row.expected
-        return None
-
+def test_region_location_with_qualifiers_resolves_via_mapping():
+    """Locations with qualifiers should map to the correct region without API calls."""
     with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
-         patch('cleaning.region_from_coordinates', side_effect=side_effect) as mock_coords:
+         patch('cleaning.region_from_coordinates') as mock_coords:
         mock_fetch.return_value = {}
-        cleaned = clean_dataframe(df.drop(columns="expected"))
+        mock_coords.return_value = "ShouldNotBeCalled"
 
-    assert cleaned["region"].tolist() == df["expected"].tolist()
-    assert mock_coords.call_count == len(rows)
+        df = pd.DataFrame({
+            "location": ["Stolberg (Rheinland)", "Frankenthal (Pfalz)"],
+            "geo_lat": [50.7891808, 49.5340652],
+            "geo_lon": [6.2235961, 8.3520517],
+        })
+
+        mapping = pd.DataFrame(
+            {
+                "location": [
+                    "Stolberg",
+                    "Stolberg",
+                    "Frankenthal",
+                    "Frankenthal",
+                ],
+                "region": [
+                    "Nordrhein-Westfalen",
+                    "Sachsen-Anhalt",
+                    "Rheinland-Pfalz",
+                    "Thüringen",
+                ],
+                "geo_lat": [50.77368, 51.57426, 49.53414, 50.8778],
+                "geo_lon": [6.22595, 10.95582, 8.35357, 12.01292],
+            }
+        )
+
+        cleaned = clean_dataframe(df, region_mapping=mapping)
+
+    assert cleaned["region"].tolist() == ["Nordrhein-Westfalen", "Rheinland-Pfalz"]
+    mock_coords.assert_not_called()
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -491,3 +491,30 @@ def test_region_api_fallback_with_unmapped_location():
         assert cleaned.loc[0, 'region'] == 'Berlin'
         mock_coords.assert_called_once()
 
+
+def test_region_api_fallback_real_world_examples():
+    """Problematic rows from the raw dataset should resolve via API fallback."""
+    rows = [
+        (12365, "Frankenthal (Pfalz)", 49.5340652, 8.3520517, "Rheinland-Pfalz"),
+        (13446, "Frankenberg (Eder)", 51.0545654, 8.7891808, "Hessen"),
+        (13504, "Gronau (Westfalen)", 52.2109108, 7.0228, "Nordrhein-Westfalen"),
+        (13544, "Stolberg (Rheinland)", 50.7891808, 6.2235961, "Nordrhein-Westfalen"),
+    ]
+    df = pd.DataFrame(rows, columns=["jobid", "location", "geo_lat", "geo_lon", "expected"])
+
+    def side_effect(lat, lon):
+        lat = float(lat)
+        lon = float(lon)
+        for _, row in df.iterrows():
+            if abs(row.geo_lat - lat) < 1e-6 and abs(row.geo_lon - lon) < 1e-6:
+                return row.expected
+        return None
+
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
+         patch('cleaning.region_from_coordinates', side_effect=side_effect) as mock_coords:
+        mock_fetch.return_value = {}
+        cleaned = clean_dataframe(df.drop(columns="expected"))
+
+    assert cleaned["region"].tolist() == df["expected"].tolist()
+    assert mock_coords.call_count == len(rows)
+

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -375,8 +375,10 @@ def test_region_enrichment_fuzzy():
 
 def test_region_enrichment_coordinates():
     """Coordinates should resolve to German federal states when names fail."""
-    with patch('cleaning.fetch_german_license_plates') as mock_fetch:
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
+         patch('cleaning.region_from_coordinates') as mock_coords:
         mock_fetch.return_value = {}
+        mock_coords.return_value = "Mecklenburg-Vorpommern"
 
         df = pd.DataFrame({
             "jobid": [19065],
@@ -388,6 +390,33 @@ def test_region_enrichment_coordinates():
         cleaned = clean_dataframe(df)
 
         assert cleaned.loc[0, "region"] == "Mecklenburg-Vorpommern"
+        mock_coords.assert_called_once()
+
+
+def test_region_coordinates_match_sql_first():
+    """Coordinate mapping via SQL should take precedence over API calls."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
+         patch('cleaning.region_from_coordinates') as mock_coords:
+        mock_fetch.return_value = {}
+        mock_coords.return_value = "ShouldNotBeCalled"
+
+        df = pd.DataFrame({
+            "location": ["Irgendwo"],
+            "geo_lat": [52.54734],
+            "geo_lon": [13.35594],
+        })
+
+        mapping = pd.DataFrame({
+            "location": ["Wedding"],
+            "region": ["Berlin"],
+            "geo_lat": [52.54734],
+            "geo_lon": [13.35594],
+        })
+
+        cleaned = clean_dataframe(df, region_mapping=mapping)
+
+        assert cleaned.loc[0, "region"] == "Berlin"
+        mock_coords.assert_not_called()
 
 
 def test_region_ambiguous_locations_use_coordinates():

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -419,12 +419,12 @@ def test_region_coordinates_match_sql_first():
         mock_coords.assert_not_called()
 
 
-def test_region_ambiguous_locations_use_coordinates():
-    """Ambiguous place names should fall back to coordinate-based lookup."""
+def test_region_ambiguous_locations_choose_nearest():
+    """Ambiguous place names should pick the closest coordinate match."""
     with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
          patch('cleaning.region_from_coordinates') as mock_coords:
         mock_fetch.return_value = {}
-        mock_coords.return_value = "Berlin"
+        mock_coords.return_value = "ShouldNotBeCalled"
 
         df = pd.DataFrame({
             "jobid": [1],
@@ -437,11 +437,13 @@ def test_region_ambiguous_locations_use_coordinates():
             {
                 "location": ["Berlin", "Berlin"],
                 "region": ["Schleswig-Holstein", "Berlin"],
+                "geo_lat": [54.0, 52.52],
+                "geo_lon": [9.0, 13.405],
             }
         )
 
         cleaned = clean_dataframe(df, region_mapping=mapping)
 
         assert cleaned.loc[0, "region"] == "Berlin"
-        mock_coords.assert_called_once()
+        mock_coords.assert_not_called()
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -429,22 +429,51 @@ def test_region_ambiguous_locations_choose_nearest():
         df = pd.DataFrame({
             "jobid": [1],
             "location": ["Berlin"],
-            "geo_lat": [52.52],
-            "geo_lon": [13.405],
+            "geo_lat": [52.5068016],
+            "geo_lon": [13.3525801],
         })
 
         mapping = pd.DataFrame(
             {
                 "location": ["Berlin", "Berlin"],
                 "region": ["Schleswig-Holstein", "Berlin"],
-                "geo_lat": [54.0, 52.52],
-                "geo_lon": [9.0, 13.405],
+                "geo_lat": [54.03518, 52.52437],
+                "geo_lon": [10.44908, 13.41053],
             }
         )
 
         cleaned = clean_dataframe(df, region_mapping=mapping)
 
         assert cleaned.loc[0, "region"] == "Berlin"
+        mock_coords.assert_not_called()
+
+
+def test_region_ambiguous_oldenburg_uses_coordinates():
+    """Ambiguous 'Oldenburg' should resolve via nearest coordinates."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
+         patch('cleaning.region_from_coordinates') as mock_coords:
+        mock_fetch.return_value = {}
+        mock_coords.return_value = "ShouldNotBeCalled"
+
+        df = pd.DataFrame({
+            "jobid": [1],
+            "location": ["Oldenburg"],
+            "geo_lat": [53.1499999],
+            "geo_lon": [8.2125],
+        })
+
+        mapping = pd.DataFrame(
+            {
+                "location": ["Oldenburg", "Oldenburg"],
+                "region": ["Mecklenburg-Vorpommern", "Niedersachsen"],
+                "geo_lat": [53.95508, 53.14118],
+                "geo_lon": [13.55661, 8.21467],
+            }
+        )
+
+        cleaned = clean_dataframe(df, region_mapping=mapping)
+
+        assert cleaned.loc[0, "region"] == "Niedersachsen"
         mock_coords.assert_not_called()
 
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -447,3 +447,21 @@ def test_region_ambiguous_locations_choose_nearest():
         assert cleaned.loc[0, "region"] == "Berlin"
         mock_coords.assert_not_called()
 
+
+def test_region_api_fallback_without_location_column():
+    """When only coordinates are available, API fallback should determine the region."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
+         patch('cleaning.load_region_mapping') as mock_mapping, \
+         patch('cleaning.region_from_coordinates') as mock_coords:
+        mock_fetch.return_value = {}
+        mock_mapping.return_value = pd.DataFrame()
+        mock_coords.return_value = "Berlin"
+
+        df = pd.DataFrame({"geo_lat": [52.52], "geo_lon": [13.405]})
+
+        cleaned = clean_dataframe(df)
+
+        assert cleaned.loc[0, "region"] == "Berlin"
+        mock_fetch.assert_not_called()
+        mock_coords.assert_called_once()
+

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -389,3 +389,30 @@ def test_region_enrichment_coordinates():
 
         assert cleaned.loc[0, "region"] == "Mecklenburg-Vorpommern"
 
+
+def test_region_ambiguous_locations_use_coordinates():
+    """Ambiguous place names should fall back to coordinate-based lookup."""
+    with patch('cleaning.fetch_german_license_plates') as mock_fetch, \
+         patch('cleaning.region_from_coordinates') as mock_coords:
+        mock_fetch.return_value = {}
+        mock_coords.return_value = "Berlin"
+
+        df = pd.DataFrame({
+            "jobid": [1],
+            "location": ["Berlin"],
+            "geo_lat": [52.52],
+            "geo_lon": [13.405],
+        })
+
+        mapping = pd.DataFrame(
+            {
+                "location": ["Berlin", "Berlin"],
+                "region": ["Schleswig-Holstein", "Berlin"],
+            }
+        )
+
+        cleaned = clean_dataframe(df, region_mapping=mapping)
+
+        assert cleaned.loc[0, "region"] == "Berlin"
+        mock_coords.assert_called_once()
+

--- a/tests/test_region_mapper.py
+++ b/tests/test_region_mapper.py
@@ -40,3 +40,20 @@ def test_region_from_coordinates_retries_after_rate_limit():
     assert result == "Berlin"
     assert mock_get.call_count == 2
     assert mock_sleep.called
+
+
+def test_region_from_coordinates_falls_back_to_secondary_service():
+    region_from_coordinates.cache_clear()
+    failure = Mock()
+    failure.ok = False
+    failure.status_code = 500
+
+    success = Mock()
+    success.ok = True
+    success.json.return_value = {"address": {"state": "State of Berlin"}}
+
+    with patch("region_mapper.requests.get", side_effect=[failure, success]) as mock_get:
+        result = region_from_coordinates(52.5, 13.4)
+
+    assert result == "Berlin"
+    assert mock_get.call_count == 2

--- a/tests/test_region_mapper.py
+++ b/tests/test_region_mapper.py
@@ -19,3 +19,24 @@ def test_region_from_coordinates_normalizes_api_response():
     with patch("region_mapper.requests.get", return_value=fake_response):
         result = region_from_coordinates(52.5, 13.4)
     assert result == "Berlin"
+
+
+def test_region_from_coordinates_retries_after_rate_limit():
+    region_from_coordinates.cache_clear()
+    rate_limited = Mock()
+    rate_limited.status_code = 429
+    rate_limited.ok = False
+
+    success = Mock()
+    success.status_code = 200
+    success.ok = True
+    success.json.return_value = {"address": {"state": "State of Berlin"}}
+
+    with patch("region_mapper.requests.get", side_effect=[rate_limited, success]) as mock_get, \
+         patch("region_mapper.time.sleep") as mock_sleep:
+        mock_sleep.return_value = None
+        result = region_from_coordinates(52.5, 13.4)
+
+    assert result == "Berlin"
+    assert mock_get.call_count == 2
+    assert mock_sleep.called

--- a/tests/test_region_mapper.py
+++ b/tests/test_region_mapper.py
@@ -1,0 +1,21 @@
+import pathlib
+from unittest.mock import Mock, patch
+
+from region_mapper import load_region_mapping, region_from_coordinates
+
+
+def test_load_region_mapping_normalizes_berlin():
+    mapping = load_region_mapping(pathlib.Path(__file__).resolve().parent.parent / "ort_bundesland.sql")
+    assert "State of Berlin" not in mapping["region"].unique()
+    berlin_regions = mapping[mapping["location"] == "Berlin"]["region"].unique()
+    assert "Berlin" in berlin_regions
+
+
+def test_region_from_coordinates_normalizes_api_response():
+    region_from_coordinates.cache_clear()
+    fake_response = Mock()
+    fake_response.ok = True
+    fake_response.json.return_value = {"address": {"state": "State of Berlin"}}
+    with patch("region_mapper.requests.get", return_value=fake_response):
+        result = region_from_coordinates(52.5, 13.4)
+    assert result == "Berlin"


### PR DESCRIPTION
This pull request significantly improves the region enrichment logic for German locations and coordinates, making the process more robust and accurate. The main enhancements include switching to an online geocoding API for coordinate-to-region mapping, prioritizing coordinate-based lookups, handling ambiguous place names using nearest coordinates, and normalizing region names from various sources. Comprehensive tests have been added to validate these changes and edge cases.

**Region enrichment logic improvements:**

* The `region_from_coordinates` function in `region_mapper.py` now uses the Nominatim API (with throttling and retry logic) to resolve coordinates to German federal states, and falls back to a secondary service if needed. Region names are normalized to match project conventions.
* In `cleaning.py`, the region enrichment pipeline prioritizes coordinate-based matching using nearest neighbors, then falls back to location-based matching (with fuzzy logic for ambiguous names), and finally uses the API if no match is found. Ambiguous locations are resolved to the closest region by coordinates.

**Region mapping normalization:**

* The region mapping loader in `region_mapper.py` now parses SQL records with coordinates and normalizes region names (e.g., "State of Berlin" becomes "Berlin").

**Debugging and diagnostics:**

* Added a `debug` flag to `clean_dataframe` in `cleaning.py` that prints detailed reasons for missing region assignments, aiding troubleshooting. [[1]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fR486) [[2]](diffhunk://#diff-f49364c862311df94d1f7be09f0962d34423cb79e7745d0dad2e3b09be51f82fL613-R695)

**Testing enhancements:**

* Extensive new tests in `tests/test_cleaning.py` and `tests/test_region_mapper.py` cover coordinate-based matching, ambiguous location resolution, API fallback, region name normalization, and rate limiting/retry scenarios. [[1]](diffhunk://#diff-6460affcd3ff926e6dd0a5315467a6f72a06a3c36126ca72344f94176dc66fc4R393-R559) [[2]](diffhunk://#diff-51a4e34535ed0316051dbd58c541caad8727f8a6bd089107a029d115bfbb12b4R1-R59)