### PR TITLE
Fix: Improve region selection logic in clean_dataframe

### DIFF
--- a/cleaning.py
+++ b/cleaning.py
@@ -483,7 +483,7 @@ def clean_dataframe(
     progress_callback: Optional[Callable[[float], None]] = None,
     status_callback: Optional[Callable[[str], None]] = None,
     region_mapping: Optional[pd.DataFrame] = None,
-    debug: bool = False,
+    debug: bool = True,
 ) -> pd.DataFrame:
     """Return a cleaned copy of *df* with HTML entities decoded, tags removed,
     license plates resolved, company names standardized, and PLZ extracted to separate column.
@@ -634,6 +634,8 @@ def clean_dataframe(
                     return None
                 if len(group) == 1:
                     return group.iloc[0]["region"]
+                
+                # Wenn Koordinaten verfügbar sind, verwende diese für die Auswahl
                 if {
                     "geo_lat",
                     "geo_lon",
@@ -645,6 +647,19 @@ def clean_dataframe(
                         + (group["geo_lon"] - row["geo_lon"]) ** 2
                     )
                     return group.loc[distances.idxmin(), "region"]
+                
+                # FALLBACK: Wenn keine Koordinaten verfügbar sind, verwende das häufigste Match
+                # oder bei eindeutigem Namen (alle Matches haben die gleiche Region) verwende diese
+                if len(group) > 1:
+                    # Überprüfe ob alle Matches zur gleichen Region gehören
+                    unique_regions = group["region"].unique()
+                    if len(unique_regions) == 1:
+                        return unique_regions[0]
+                    
+                    # Andernfalls verwende das häufigste Match
+                    region_counts = group["region"].value_counts()
+                    return region_counts.index[0]
+                
                 return None
 
             missing_mask = cleaned["region"].isna() & cleaned["location"].notna()


### PR DESCRIPTION
This pull request introduces improvements to the location resolution logic in `cleaning.py`, specifically enhancing how ambiguous locations are handled and making debugging easier. The main changes are focused on the `_resolve_location` function, adding fallback mechanisms and clarifying the selection process when multiple matches are found.

Enhancements to location resolution:

* Added a fallback in `_resolve_location` to handle cases where multiple matches exist but no coordinates are available: it now checks if all matches belong to the same region and uses that, otherwise it selects the most frequent region among matches.
* Improved the documentation and code comments to clarify the logic for selecting regions when coordinates are available or not.

Debugging improvements:

* Changed the default value of the `debug` parameter in `clean_dataframe` to `True` for easier debugging during development.