### PR TITLE
Add check to skip data warehouse creation if tables already filled

### DIFF
--- a/data_warehouse.py
+++ b/data_warehouse.py
@@ -5,6 +5,66 @@ import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 
+def is_data_warehouse_initialized(
+    df: pd.DataFrame, conn_info: Dict[str, str | int]
+) -> bool:
+    """Return ``True`` if all tables exist with expected row counts.
+
+    The expected counts are derived from ``df`` and compared with the
+    contents of the target database defined by ``conn_info``.
+    """
+
+    host = conn_info.get("host", "localhost")
+    port = int(conn_info.get("port", 5432))
+    user = conn_info.get("user", "postgres")
+    password = conn_info.get("password", "")
+    dbname = conn_info.get("dbname", "datawarehouse")
+
+    try:
+        conn = psycopg2.connect(
+            host=host, port=port, user=user, password=password, dbname=dbname
+        )
+    except Exception:
+        return False
+
+    cur = conn.cursor()
+    tables = {"dim_company", "dim_location", "dim_jobtype", "fact_job"}
+    cur.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
+    )
+    existing = {row[0] for row in cur.fetchall()}
+    if not tables.issubset(existing):
+        cur.close()
+        conn.close()
+        return False
+
+    company_expected = len(df[["company", "insttype"]].drop_duplicates())
+    location_expected = len(
+        df[["location", "country", "geo_lat", "geo_lon", "plz", "region"]]
+        .drop_duplicates()
+    )
+    jobtype_expected = len(df[["jobtype"]].drop_duplicates())
+    fact_expected = len(df)
+
+    cur.execute("SELECT COUNT(*) FROM dim_company")
+    company_count = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(*) FROM dim_location")
+    location_count = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(*) FROM dim_jobtype")
+    jobtype_count = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(*) FROM fact_job")
+    fact_count = cur.fetchone()[0]
+    cur.close()
+    conn.close()
+
+    return (
+        company_count == company_expected
+        and location_count == location_expected
+        and jobtype_count == jobtype_expected
+        and fact_count == fact_expected
+    )
+
+
 def create_data_warehouse(
     df: pd.DataFrame,
     conn_info: Dict[str, str | int],

--- a/start.py
+++ b/start.py
@@ -26,7 +26,7 @@ from cleaning import (
     prepare_duplicates_export,
     format_export_columns,
 )
-from data_warehouse import create_data_warehouse
+from data_warehouse import create_data_warehouse, is_data_warehouse_initialized
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from werkzeug.serving import BaseWSGIServer
@@ -788,6 +788,23 @@ class DataWarehouseWindow(QtWidgets.QDialog):
             return
 
         self._save_settings(info)
+
+        try:
+            if is_data_warehouse_initialized(self._dataframe, info):
+                skip = True
+                if os.environ.get("QT_QPA_PLATFORM") != "offscreen":
+                    result = QtWidgets.QMessageBox.question(
+                        self,
+                        "Datenbank vorhanden",
+                        "Alle Tabellen sind bereits vorhanden und enthalten die erwartete Anzahl an Datensätzen.\n"
+                        "Möchten Sie die Erstellung überspringen?",
+                    )
+                    skip = result == QtWidgets.QMessageBox.StandardButton.Yes
+                if skip:
+                    self.accept()
+                    return
+        except psycopg2.Error:
+            pass
 
         self._create_button.setEnabled(False)
         self._status.show()


### PR DESCRIPTION
This pull request introduces a new safeguard to the data warehouse creation workflow. Before attempting to create tables, the code now checks if all expected tables exist and contain the correct number of rows. If the database is already properly initialized, users are prompted to skip redundant creation, improving efficiency and user experience.

**Data warehouse initialization check:**

* Added a new function `is_data_warehouse_initialized` to `data_warehouse.py` that verifies the existence of all required tables (`dim_company`, `dim_location`, `dim_jobtype`, `fact_job`) and checks if their row counts match expectations derived from the input DataFrame.

**User experience improvements:**

* Updated the creation workflow in `start.py` to call `is_data_warehouse_initialized` before proceeding. If initialization is confirmed, the user is prompted to skip the creation step, avoiding unnecessary operations.
* Imported the new function in `start.py` for use in the workflow.