### PR TITLE
Move and rename geographic dashboard card

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -75,6 +75,14 @@ TEMPLATE = """
             <div class="col-12">
                 <div class="card">
                     <div class="card-body">
+                        <h5 class="card-title">Geografische Lage der Stellen</h5>
+                        <div id="map" style="height: 500px;"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
                         <h5 class="card-title">Stellen nach Bundesland</h5>
                         <ul class="list-group list-group-flush">
                             {% for region, count in regions %}
@@ -84,14 +92,6 @@ TEMPLATE = """
                             </li>
                             {% endfor %}
                         </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="col-12">
-                <div class="card">
-                    <div class="card-body">
-                        <h5 class="card-title">Stellenübersicht</h5>
-                        <div id="map" style="height: 500px;"></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This pull request updates the dashboard layout to improve clarity and user experience by moving the map display to a dedicated card with a more descriptive title. The previous placement of the map within the "Stellenübersicht" card has been removed, and a new card titled "Geografische Lage der Stellen" now contains the map.

Dashboard layout changes:

* Added a new card with the title "Geografische Lage der Stellen" and placed the map element (`<div id="map">`) inside it for better context and visibility. (`dashboard.py`, [dashboard.pyR75-R82](diffhunk://#diff-0b33aef4b18b18a32444e65bdef64f6431c2e6cf844a820cf75ae09a73bcf535R75-R82))
* Removed the map element from the "Stellenübersicht" card, ensuring that the map is only shown in the new dedicated card. (`dashboard.py`, [dashboard.pyL90-L97](diffhunk://#diff-0b33aef4b18b18a32444e65bdef64f6431c2e6cf844a820cf75ae09a73bcf535L90-L97))