### PR TITLE
Improve word cloud clarity

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -32,9 +32,9 @@ INSTTYPE_NAMES = {
     "informationseinrichtung": "Informationseinrichtung",
     "oeffentliche-bibliothek": "Öffentliche Bibliothek",
     "spezialbibliothek": "Spezialbibliothek",
-    "sonstige-Einrichtung": "Sonstige",
+    "sonstige-einrichtung": "Sonstige",
     "archiv": "Archiv",
-    "wissenschaftliche-Bibliothek": "Wissenschaftliche Bibliothek",
+    "wissenschaftliche-bibliothek": "Wissenschaftliche Bibliothek",
     "bibliothek": "Bibliothek",
 }
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -41,8 +41,8 @@ INSTTYPE_NAMES = {
 
 # Parameters for the employer word cloud. Adjust these values to tweak
 # the appearance of the visualization.
-WC_WIDTH = 400
-WC_HEIGHT = 250
+WC_WIDTH = 800
+WC_HEIGHT = 500
 WC_BACKGROUND_COLOR = "white"
 WC_MAX_WORDS = 10
 WC_PREFER_HORIZONTAL = 0.5  # 0 = vertical, 1 = horizontal
@@ -112,7 +112,7 @@ TEMPLATE = """
                             <img
                                 src="data:image/png;base64,{{ company_cloud }}"
                                 alt="Top 10 Arbeitgeber"
-                                class="img-fluid w-100 mx-auto"
+                                class="img-fluid mx-auto"
                                 style="object-fit: contain;"
                             />
                         </div>


### PR DESCRIPTION
This pull request updates the employer word cloud visualization in `dashboard.py` to improve its appearance and layout. The most important changes include increasing the size of the word cloud and adjusting the image styling for better display.

Word cloud visualization improvements:
* Increased the word cloud dimensions by doubling `WC_WIDTH` from 400 to 800 and `WC_HEIGHT` from 250 to 500, allowing for a larger and more readable visualization.

Image styling adjustments:
* Removed the `w-100` class from the word cloud image to prevent it from stretching to full container width, resulting in a better aspect ratio and display.