### PR TITLE
Handle updated WordCloud API and robust coordinate parsing

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -45,7 +45,10 @@ WC_HEIGHT = 500
 WC_BACKGROUND_COLOR = "white"
 WC_MAX_WORDS = 10
 WC_PREFER_HORIZONTAL = 0.5  # 0 = vertical, 1 = horizontal
-WC_RELATIVE_SCALING = 0.5   # 0 = uniform sizes, 1 = frequency based
+# ``relative_scaling`` now expects a string literal ``"auto"`` instead of a float
+# value. ``"auto"`` corresponds to ``0.5`` when ``repeat`` is ``False`` and thus
+# preserves the behaviour that was previously configured with the numeric value.
+WC_RELATIVE_SCALING: float | str = "auto"
 WC_RANDOM_STATE: int | None = None
 
 
@@ -336,8 +339,13 @@ def create_app(conn_info: dict[str, str | int]) -> Flask:
                 coords = plz_cache.get(plz)
                 if coords is None and plz not in plz_cache:
                     result = geocoder.query_postal_code(plz)
-                    if not math.isnan(result.latitude) and not math.isnan(result.longitude):
-                        coords = (float(result.latitude), float(result.longitude))
+                    lat_raw = result.latitude
+                    lon_raw = result.longitude
+                    if isinstance(lat_raw, (int, float)) and isinstance(lon_raw, (int, float)):
+                        lat_val = float(lat_raw)
+                        lon_val = float(lon_raw)
+                        if not math.isnan(lat_val) and not math.isnan(lon_val):
+                            coords = (lat_val, lon_val)
                     plz_cache[plz] = coords
                 coords = plz_cache.get(plz)
                 if coords:

--- a/dashboard.py
+++ b/dashboard.py
@@ -48,7 +48,7 @@ WC_PREFER_HORIZONTAL = 0.5  # 0 = vertical, 1 = horizontal
 # ``relative_scaling`` now expects a string literal ``"auto"`` instead of a float
 # value. ``"auto"`` corresponds to ``0.5`` when ``repeat`` is ``False`` and thus
 # preserves the behaviour that was previously configured with the numeric value.
-WC_RELATIVE_SCALING: float | str = "auto"
+WC_RELATIVE_SCALING: str = "auto"
 WC_RANDOM_STATE: int | None = None
 
 


### PR DESCRIPTION
This pull request updates the `dashboard.py` file with a change to the configuration of word cloud scaling and improves the robustness of geocoding logic for postal codes. The most significant updates are a switch to a string-based configuration for relative scaling and enhanced type checking for latitude and longitude values.

Configuration update:

* Changed `WC_RELATIVE_SCALING` to accept the string literal `"auto"` instead of a float, preserving previous behavior and aligning with updated expectations for word cloud configuration. (`[dashboard.pyL48-R51](diffhunk://#diff-0b33aef4b18b18a32444e65bdef64f6431c2e6cf844a820cf75ae09a73bcf535L48-R51)`)

Geocoding logic improvement:

* Improved the handling of latitude and longitude values by adding type checks before conversion and NaN validation, making the code more robust against unexpected data types from the geocoder. (`[dashboard.pyL339-R348](diffhunk://#diff-0b33aef4b18b18a32444e65bdef64f6431c2e6cf844a820cf75ae09a73bcf535L339-R348)`)